### PR TITLE
sirupsen-case for fabric8-notification

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/spf13/viper"

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 84f7b9474686211e96d652c2cd669e5931fb47f13a3af3b3713dfff92931d63d
-updated: 2017-09-29T10:56:18.73209855+02:00
+hash: e9c2dd3f153900f651e157098e50db010f674b3ae184c5bbecdb49a5ab6683ba
+updated: 2017-09-29T15:43:38.683918727+02:00
 imports:
 - name: github.com/armon/go-metrics
   version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
@@ -14,7 +14,7 @@ imports:
   subpackages:
   - go-bindata-assetfs
 - name: github.com/fabric8-services/fabric8-wit
-  version: 58db841e76891f1251bdec86908c61360f11d375
+  version: 4419b9ea51938829dfdf18aad659ac34c7d01488
   subpackages:
   - configuration
   - design
@@ -49,7 +49,7 @@ imports:
   - middleware/security/jwt
   - uuid
 - name: github.com/gregjones/httpcache
-  version: 0d2297f241a3503b4d464cd434e6d1490ec76e9a
+  version: c1f8028e62adb3d518b823a2f8e6a95c38bdd3aa
 - name: github.com/hashicorp/hcl
   version: 37ab263305aaeb501a60eb16863e808d426e37f2
   subpackages:
@@ -83,8 +83,10 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
-- name: github.com/sirupsen/logrus
+- name: github.com/Sirupsen/logrus
   version: 89742aefa4b206dcf400792f3bd35b542998eb3b
+- name: github.com/sirupsen/logrus
+  version: c078b1e43f58d563c74cebe63c85789e76ddb627
 - name: github.com/spf13/afero
   version: 2f30b2a92c0e5700bcfe4715891adb1f2a7a406d
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: f875c6dfb774e9364c3caa3ae098a5d75d65afc04a69d4d05e2a11893791a571
-updated: 2017-08-24T05:24:29.31397775+02:00
+hash: 84f7b9474686211e96d652c2cd669e5931fb47f13a3af3b3713dfff92931d63d
+updated: 2017-09-29T10:56:18.73209855+02:00
 imports:
 - name: github.com/armon/go-metrics
   version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
@@ -29,7 +29,7 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/goadesign/goa
-  version: 58f3177f36f2c50ee6119da92795e48bac6d6243
+  version: 5646a430cdeb66983d5ace3384e0a667c185abc7
   vcs: git
   subpackages:
   - client
@@ -83,8 +83,8 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
-- name: github.com/Sirupsen/logrus
-  version: c078b1e43f58d563c74cebe63c85789e76ddb627
+- name: github.com/sirupsen/logrus
+  version: 89742aefa4b206dcf400792f3bd35b542998eb3b
 - name: github.com/spf13/afero
   version: 2f30b2a92c0e5700bcfe4715891adb1f2a7a406d
   subpackages:
@@ -101,6 +101,10 @@ imports:
   version: 651d9d916abc3c3d6a91a12549495caba5edffd2
 - name: github.com/zach-klippenstein/goregen
   version: 795b5e3961ea1912fde60af417ad85e86acc0d6a
+- name: golang.org/x/crypto
+  version: 81e90905daefcd6fd217b62423c0908922eadb30
+  subpackages:
+  - ssh/terminal
 - name: golang.org/x/net
   version: b1a2d6e8c8b5fc8f601ead62536f02a8e1b6217d
   subpackages:
@@ -109,6 +113,7 @@ imports:
   version: 478fcf54317e52ab69f40bb4c7a1520288d7f7ea
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/text
   version: 47a200a05c8b3fd1b698571caecbb68beb2611ec
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -14,7 +14,7 @@ import:
 - package: github.com/gregjones/httpcache
 - package: github.com/mattbaird/gochimp
 - package: github.com/goadesign/goa
-  version: ^1.2.0
+  version: ^1.3.0
   vcs: git
   subpackages:
   - client

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,6 @@ package: github.com/fabric8-services/fabric8-notification
 license: Apache-2.0
 import:
 - package: github.com/fabric8-services/fabric8-wit
-  version: 58db841e76891f1251bdec86908c61360f11d375
   subpackages:
     - log
     - errors

--- a/glide.yaml
+++ b/glide.yaml
@@ -34,7 +34,7 @@ import:
 - package: github.com/zach-klippenstein/goregen
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: github.com/lib/pq
 - package: gopkg.in/yaml.v2
 - package: github.com/jteeuwen/go-bindata

--- a/main.go
+++ b/main.go
@@ -13,13 +13,13 @@ import (
 	"github.com/fabric8-services/fabric8-notification/template"
 	"github.com/fabric8-services/fabric8-notification/wit"
 
-	"github.com/Sirupsen/logrus"
 	witmiddleware "github.com/fabric8-services/fabric8-wit/goamiddleware"
 	"github.com/fabric8-services/fabric8-wit/log"
 	"github.com/goadesign/goa"
 	"github.com/goadesign/goa/middleware"
 	"github.com/goadesign/goa/middleware/gzip"
 	goajwt "github.com/goadesign/goa/middleware/security/jwt"
+	"github.com/sirupsen/logrus"
 
 	goalogrus "github.com/goadesign/goa/logging/logrus"
 )


### PR DESCRIPTION
Switched from github.com/Sirupsen/logrus to github.com/sirupsen/logrus

This commit will probably not build because not all packages that this
project depends on have adopted the lowercase version of the package. We
have to merge this commit anyway, I think.

Also updated GOA to 1.3.0

See also https://github.com/fabric8-services/fabric8-wit/issues/1395