### PR TITLE
Support notifications to users with private email ( using fabric8 service account )

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,7 @@ tool/cli/
 migration/sqlbindata.go
 template/bindata.go
 wit/api
+auth/api
 
 # Ignore artifacts directory
 bin/

--- a/Makefile
+++ b/Makefile
@@ -186,6 +186,7 @@ clean-generated:
 	-rm -rf ./swagger/
 	-rm -f ./migration/sqlbindata.go
 	-rm -f ./template/bindata.go
+	-rm -rf auth
 
 CLEAN_TARGETS += clean-vendor
 .PHONY: clean-vendor
@@ -211,6 +212,7 @@ app/controllers.go: $(DESIGNS) $(GOAGEN_BIN) $(VENDOR_DIR)
 	$(GOAGEN_BIN) app -d ${PACKAGE_NAME}/${DESIGN_DIR}
 	$(GOAGEN_BIN) controller -d ${PACKAGE_NAME}/${DESIGN_DIR} -o controller/ --pkg controller --app-pkg app
 	$(GOAGEN_BIN) client -d github.com/fabric8-services/fabric8-wit/design --notool --pkg api -o wit
+	$(GOAGEN_BIN) client -d github.com/fabric8-services/fabric8-auth/design --notool --pkg api -o auth
 
 .PHONY: migrate-database
 ## Compiles the server and runs the database migration with it

--- a/Makefile
+++ b/Makefile
@@ -186,7 +186,7 @@ clean-generated:
 	-rm -rf ./swagger/
 	-rm -f ./migration/sqlbindata.go
 	-rm -f ./template/bindata.go
-	-rm -rf auth
+	-rm -rf auth/api
 
 CLEAN_TARGETS += clean-vendor
 .PHONY: clean-vendor

--- a/auth/client.go
+++ b/auth/client.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"fmt"
+
+	"github.com/fabric8-services/fabric8-notification/auth/api"
+	"github.com/fabric8-services/fabric8-wit/goasupport"
+	goaclient "github.com/goadesign/goa/client"
+	"github.com/goadesign/goa/uuid"
+	"github.com/gregjones/httpcache"
+)
+
+func NewCachedClient(hostURL string) (*api.Client, error) {
+
+	u, err := url.Parse(hostURL)
+	if err != nil {
+		return nil, err
+	}
+
+	tp := httpcache.NewMemoryCacheTransport()
+	client := http.Client{Transport: tp}
+
+	c := api.New(goaclient.HTTPClientDoer(&client))
+	c.Host = u.Host
+	c.Scheme = u.Scheme
+	return c, nil
+}
+
+func GetUser(ctx context.Context, client *api.Client, uID uuid.UUID) (*api.User, error) {
+	resp, err := client.ShowUsers(goasupport.ForwardContextRequestID(ctx), api.ShowUsersPath(uID.String()), nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET user", resp.StatusCode)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return client.DecodeUser(resp)
+}
+
+func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid.UUID) (*api.UserList, error) {
+	pageLimit := 100
+	pageOffset := "0"
+	resp, err := client.ListCollaborators(goasupport.ForwardContextRequestID(ctx), api.ListCollaboratorsPath(spaceID), &pageLimit, &pageOffset, nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET collaborators", resp.StatusCode)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return client.DecodeUserList(resp)
+}

--- a/auth/client.go
+++ b/auth/client.go
@@ -14,17 +14,6 @@ import (
 	"github.com/gregjones/httpcache"
 )
 
-func SecureClient(authClient *api.Client, token string) (*api.Client, error) {
-	authClient.SetJWTSigner(&goaclient.JWTSigner{
-		TokenSource: &goaclient.StaticTokenSource{
-			StaticToken: &goaclient.StaticToken{
-				Value: token,
-			},
-		},
-	})
-	return authClient, nil
-}
-
 func NewCachedClient(hostURL string) (*api.Client, error) {
 
 	u, err := url.Parse(hostURL)
@@ -39,22 +28,6 @@ func NewCachedClient(hostURL string) (*api.Client, error) {
 	c.Host = u.Host
 	c.Scheme = u.Scheme
 	return c, nil
-}
-
-func GetUser(ctx context.Context, client *api.Client, uID uuid.UUID) (*api.User, error) {
-	resp, err := client.ShowUsers(goasupport.ForwardContextRequestID(ctx), api.ShowUsersPath(uID.String()), nil, nil)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET user", resp.StatusCode)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	return client.DecodeUser(resp)
 }
 
 func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid.UUID) (*api.UserList, error) {

--- a/auth/client.go
+++ b/auth/client.go
@@ -74,3 +74,18 @@ func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid
 	}
 	return client.DecodeUserList(resp)
 }
+
+func GetServiceAccountToken(ctx context.Context, client *api.Client, serviceAccountID string, serviceAccountSecret string) (*api.OauthToken, error) {
+	payload := api.TokenExchange{
+		ClientID:     serviceAccountID,
+		ClientSecret: &serviceAccountSecret,
+		GrantType:    "client_credentials",
+	}
+	resp, err := client.ExchangeToken(goasupport.ForwardContextRequestID(ctx), api.ExchangeTokenPath(), &payload, "application/x-www-form-urlencoded")
+
+	if err != nil {
+		return nil, err
+	}
+
+	return client.DecodeOauthToken(resp)
+}

--- a/auth/client.go
+++ b/auth/client.go
@@ -14,6 +14,17 @@ import (
 	"github.com/gregjones/httpcache"
 )
 
+func SecureClient(authClient *api.Client, token string) (*api.Client, error) {
+	authClient.SetJWTSigner(&goaclient.JWTSigner{
+		TokenSource: &goaclient.StaticTokenSource{
+			StaticToken: &goaclient.StaticToken{
+				Value: token,
+			},
+		},
+	})
+	return authClient, nil
+}
+
 func NewCachedClient(hostURL string) (*api.Client, error) {
 
 	u, err := url.Parse(hostURL)
@@ -62,18 +73,4 @@ func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid
 		return nil, err
 	}
 	return client.DecodeUserList(resp)
-}
-
-func GetServiceAccountToken(ctx context.Context, client *api.Client, serviceAccountID string, serviceAccountSecret string) (*api.OauthToken, error) {
-	payload := api.TokenExchange{
-		ClientID:     serviceAccountID,
-		ClientSecret: &serviceAccountSecret,
-	}
-	resp, err := client.ExchangeToken(goasupport.ForwardContextRequestID(ctx), api.ExchangeTokenPath(), &payload, "application/x-www-form-urlencoded")
-
-	if err != nil {
-		return nil, err
-	}
-
-	return client.DecodeOauthToken(resp)
 }

--- a/auth/client.go
+++ b/auth/client.go
@@ -34,6 +34,9 @@ func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid
 	pageLimit := 100
 	pageOffset := "0"
 	resp, err := client.ListCollaborators(goasupport.ForwardContextRequestID(ctx), api.ListCollaboratorsPath(spaceID), &pageLimit, &pageOffset, nil, nil)
+	if err != nil {
+		return nil, err
+	}
 	if resp != nil {
 		defer resp.Body.Close()
 	} else {
@@ -42,10 +45,6 @@ func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET collaborators", resp.StatusCode)
-	}
-
-	if err != nil {
-		return nil, err
 	}
 	return client.DecodeUserList(resp)
 }

--- a/auth/client.go
+++ b/auth/client.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/fabric8-services/fabric8-notification/auth/api"
 	"github.com/fabric8-services/fabric8-wit/goasupport"
-	"github.com/fabric8-services/fabric8-wit/log"
 	goaclient "github.com/goadesign/goa/client"
 	"github.com/goadesign/goa/uuid"
 	"github.com/gregjones/httpcache"

--- a/auth/client.go
+++ b/auth/client.go
@@ -63,3 +63,17 @@ func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid
 	}
 	return client.DecodeUserList(resp)
 }
+
+func GetServiceAccountToken(ctx context.Context, client *api.Client, serviceAccountID string, serviceAccountSecret string) (*api.OauthToken, error) {
+	payload := api.TokenExchange{
+		ClientID:     serviceAccountID,
+		ClientSecret: &serviceAccountSecret,
+	}
+	resp, err := client.ExchangeToken(goasupport.ForwardContextRequestID(ctx), api.ExchangeTokenPath(), &payload, "application/x-www-form-urlencoded")
+
+	if err != nil {
+		return nil, err
+	}
+
+	return client.DecodeOauthToken(resp)
+}

--- a/auth/client.go
+++ b/auth/client.go
@@ -36,6 +36,8 @@ func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid
 	resp, err := client.ListCollaborators(goasupport.ForwardContextRequestID(ctx), api.ListCollaboratorsPath(spaceID), &pageLimit, &pageOffset, nil, nil)
 	if resp != nil {
 		defer resp.Body.Close()
+	} else {
+		return nil, fmt.Errorf("failed to make request to get list of collaborators")
 	}
 
 	if resp.StatusCode != http.StatusOK {

--- a/auth/client.go
+++ b/auth/client.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/fabric8-services/fabric8-notification/auth/api"
 	"github.com/fabric8-services/fabric8-wit/goasupport"
+	"github.com/fabric8-services/fabric8-wit/log"
 	goaclient "github.com/goadesign/goa/client"
 	"github.com/goadesign/goa/uuid"
 	"github.com/gregjones/httpcache"
@@ -46,19 +47,4 @@ func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid
 		return nil, err
 	}
 	return client.DecodeUserList(resp)
-}
-
-func GetServiceAccountToken(ctx context.Context, client *api.Client, serviceAccountID string, serviceAccountSecret string) (*api.OauthToken, error) {
-	payload := api.TokenExchange{
-		ClientID:     serviceAccountID,
-		ClientSecret: &serviceAccountSecret,
-		GrantType:    "client_credentials",
-	}
-	resp, err := client.ExchangeToken(goasupport.ForwardContextRequestID(ctx), api.ExchangeTokenPath(), &payload, "application/x-www-form-urlencoded")
-
-	if err != nil {
-		return nil, err
-	}
-
-	return client.DecodeOauthToken(resp)
 }

--- a/auth/client_test.go
+++ b/auth/client_test.go
@@ -1,0 +1,36 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-notification/auth"
+	"github.com/fabric8-services/fabric8-notification/auth/api"
+	"github.com/goadesign/goa/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	openshiftIOAPI = "http://auth.openshift.io"
+)
+
+func createClient(t *testing.T) *api.Client {
+	c, err := auth.NewCachedClient(openshiftIOAPI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c
+}
+
+func TestSpaceCollaborators(t *testing.T) {
+
+	c := createClient(t)
+	id, _ := uuid.FromString("020f756e-b51a-4b43-b113-45cec16b9ce9")
+
+	u, err := auth.GetSpaceCollaborators(context.Background(), c, id)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.True(t, len(u.Data) > 10)
+}

--- a/auth/user_client.go
+++ b/auth/user_client.go
@@ -1,0 +1,77 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"fmt"
+
+	"github.com/fabric8-services/fabric8-notification/auth/api"
+	"github.com/fabric8-services/fabric8-wit/goasupport"
+	"github.com/goadesign/goa/uuid"
+)
+
+/*
+	Took out the auth api client code relevant to User API in order to add a custom
+	client.JWTSigner.Sign(req) before the http request is made.
+
+	This wasn't present in the auto-generated client for GET /api/users/ID
+	because we don't set "a.Security("jwt")" in auth's design/account.go
+	for the `Show Users` action.
+*/
+
+func GetUser(ctx context.Context, client *api.Client, uID uuid.UUID) (*api.User, error) {
+	resp, err := showUsers(goasupport.ForwardContextRequestID(ctx), client, api.ShowUsersPath(uID.String()), nil, nil)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET user", resp.StatusCode)
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	return client.DecodeUser(resp)
+}
+
+// retrieve user for the given ID.
+func showUsers(ctx context.Context, client *api.Client, path string, ifModifiedSince *string, ifNoneMatch *string) (*http.Response, error) {
+	req, err := newShowUsersRequest(ctx, client, path, ifModifiedSince, ifNoneMatch)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(ctx, req)
+}
+
+// bewShowUsersRequest create the request corresponding to the show action endpoint of the users resource.
+func newShowUsersRequest(ctx context.Context, client *api.Client, path string, ifModifiedSince *string, ifNoneMatch *string) (*http.Request, error) {
+	scheme := client.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	u := url.URL{Host: client.Host, Scheme: scheme, Path: path}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	header := req.Header
+	if ifModifiedSince != nil {
+
+		header.Set("If-Modified-Since", *ifModifiedSince)
+	}
+	if ifNoneMatch != nil {
+
+		header.Set("If-None-Match", *ifNoneMatch)
+	}
+
+	// This wasn't present in the auto-generated client for GET /api/users/ID
+	// because we don't set "a.Security("jwt")" in auth's design/account.go
+	// for the `Show Users` action.
+	if client.JWTSigner != nil {
+		client.JWTSigner.Sign(req)
+	}
+	return req, nil
+}

--- a/auth/user_client.go
+++ b/auth/user_client.go
@@ -46,7 +46,7 @@ func showUsers(ctx context.Context, client *api.Client, path string, ifModifiedS
 	return client.Do(ctx, req)
 }
 
-// bewShowUsersRequest create the request corresponding to the show action endpoint of the users resource.
+// newShowUsersRequest create the request corresponding to the show action endpoint of the users resource.
 func newShowUsersRequest(ctx context.Context, client *api.Client, path string, ifModifiedSince *string, ifNoneMatch *string) (*http.Request, error) {
 	scheme := client.Scheme
 	if scheme == "" {

--- a/collector/user.go
+++ b/collector/user.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/fabric8-services/fabric8-notification/wit/api"
+	"github.com/fabric8-services/fabric8-notification/auth/api"
 	"github.com/goadesign/goa/uuid"
 )
 

--- a/collector/user_test.go
+++ b/collector/user_test.go
@@ -10,9 +10,9 @@ import (
 )
 
 func TestUser(t *testing.T) {
-	c := createClient(t)
+	_, authClient := createClient(t)
 	uID, _ := uuid.FromString("3383826c-51e4-401b-9ccd-b898f7e2397d")
-	users, vars, err := collector.User(context.Background(), c, uID)
+	users, vars, err := collector.User(context.Background(), authClient, uID)
 
 	assert.Nil(t, err)
 	assert.Len(t, users, 1)

--- a/collector/workitem.go
+++ b/collector/workitem.go
@@ -59,7 +59,7 @@ func Comment(ctx context.Context, authClient *authapi.Client, c *api.Client, cID
 	values["comment"] = comment
 	users = append(users, collectCommentUsers(comment)...)
 
-	commentOwner, err := wit.GetUser(ctx, c, *comment.Data.Relationships.CreatedBy.Data.ID)
+	commentOwner, err := auth.GetUser(ctx, authClient, *comment.Data.Relationships.CreatedBy.Data.ID)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -75,7 +75,7 @@ func Comment(ctx context.Context, authClient *authapi.Client, c *api.Client, cID
 	values["workitem"] = wi
 
 	ownerID, _ := uuid.FromString(*wi.Data.Relationships.Creator.Data.ID)
-	workitemOwner, err := wit.GetUser(ctx, c, ownerID)
+	workitemOwner, err := auth.GetUser(ctx, authClient, ownerID)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -102,7 +102,7 @@ func Comment(ctx context.Context, authClient *authapi.Client, c *api.Client, cID
 	users = append(users, collectSpaceUsers(s)...)
 	values["space"] = s
 
-	spaceOwner, err := wit.GetUser(ctx, c, *s.Data.Relationships.OwnedBy.Data.ID)
+	spaceOwner, err := auth.GetUser(ctx, authClient, *s.Data.Relationships.OwnedBy.Data.ID)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -116,7 +116,7 @@ func Comment(ctx context.Context, authClient *authapi.Client, c *api.Client, cID
 
 	actorID, err := getActorID(ctx)
 	if err == nil {
-		actor, err := wit.GetUser(ctx, c, actorID)
+		actor, err := auth.GetUser(ctx, authClient, actorID)
 		if err != nil {
 			errors = append(errors, err)
 		}
@@ -155,7 +155,7 @@ func WorkItem(ctx context.Context, authclient *authapi.Client, c *api.Client, wi
 	users = append(users, collectWorkItemUsers(wi)...)
 
 	ownerID, _ := uuid.FromString(*wi.Data.Relationships.Creator.Data.ID)
-	workitemOwner, err := wit.GetUser(ctx, c, ownerID)
+	workitemOwner, err := auth.GetUser(ctx, authclient, ownerID)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -182,7 +182,7 @@ func WorkItem(ctx context.Context, authclient *authapi.Client, c *api.Client, wi
 	values["space"] = s
 	users = append(users, collectSpaceUsers(s)...)
 
-	spaceOwner, err := wit.GetUser(ctx, c, *s.Data.Relationships.OwnedBy.Data.ID)
+	spaceOwner, err := auth.GetUser(ctx, authclient, *s.Data.Relationships.OwnedBy.Data.ID)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -196,7 +196,7 @@ func WorkItem(ctx context.Context, authclient *authapi.Client, c *api.Client, wi
 
 	actorID, err := getActorID(ctx)
 	if err == nil {
-		actor, err := wit.GetUser(ctx, c, actorID)
+		actor, err := auth.GetUser(ctx, authclient, actorID)
 		if err != nil {
 			errors = append(errors, err)
 		}

--- a/collector/workitem.go
+++ b/collector/workitem.go
@@ -2,7 +2,7 @@ package collector
 
 import (
 	"context"
-	"fmt"
+	"fmt"detailURL
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-notification/auth"

--- a/collector/workitem.go
+++ b/collector/workitem.go
@@ -2,7 +2,7 @@ package collector
 
 import (
 	"context"
-	"fmt"detailURL
+	"fmt"
 
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/fabric8-services/fabric8-notification/auth"

--- a/collector/workitem.go
+++ b/collector/workitem.go
@@ -129,7 +129,7 @@ func Comment(ctx context.Context, authClient *authapi.Client, c *api.Client, cID
 	}
 	users = append(users, collectSpaceCollaboratorUsers(sc)...)
 
-	resolved, err := resolveAllUsers(ctx, c, SliceUniq(users), sc.Data)
+	resolved, err := resolveAllUsers(ctx, authClient, SliceUniq(users), sc.Data)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -209,7 +209,7 @@ func WorkItem(ctx context.Context, authclient *authapi.Client, c *api.Client, wi
 	}
 	users = append(users, collectSpaceCollaboratorUsers(sc)...)
 
-	resolved, err := resolveAllUsers(ctx, c, SliceUniq(users), sc.Data)
+	resolved, err := resolveAllUsers(ctx, authclient, SliceUniq(users), sc.Data)
 	if err != nil {
 		errors = append(errors, err)
 	}
@@ -222,7 +222,7 @@ func WorkItem(ctx context.Context, authclient *authapi.Client, c *api.Client, wi
 	return resolved, values, nil
 }
 
-func resolveAllUsers(ctx context.Context, c *api.Client, users []uuid.UUID, collaborators []*authapi.UserData) ([]Receiver, error) {
+func resolveAllUsers(ctx context.Context, c *authapi.Client, users []uuid.UUID, collaborators []*authapi.UserData) ([]Receiver, error) {
 	var resolved []Receiver
 
 	for _, u := range users {
@@ -240,7 +240,7 @@ func resolveAllUsers(ctx context.Context, c *api.Client, users []uuid.UUID, coll
 			}
 		}
 		if !found {
-			usr, err := wit.GetUser(ctx, c, u)
+			usr, err := auth.GetUser(ctx, c, u)
 			if err == nil {
 				if usr.Data.Attributes.Email != nil {
 					user := Receiver{EMail: *usr.Data.Attributes.Email}

--- a/collector/workitem_test.go
+++ b/collector/workitem_test.go
@@ -4,31 +4,39 @@ import (
 	"context"
 	"testing"
 
+	"github.com/fabric8-services/fabric8-notification/auth"
+	authApi "github.com/fabric8-services/fabric8-notification/auth/api"
 	"github.com/fabric8-services/fabric8-notification/collector"
 	"github.com/fabric8-services/fabric8-notification/wit"
-	"github.com/fabric8-services/fabric8-notification/wit/api"
+	witApi "github.com/fabric8-services/fabric8-notification/wit/api"
 	"github.com/goadesign/goa/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
 const (
-	OpenshiftIOAPI = "http://api.openshift.io"
+	OpenshiftIOAPI     = "http://api.openshift.io"
+	OpenShiftIOAuthAPI = "https://auth.openshift.io"
 )
 
-func createClient(t *testing.T) *api.Client {
+func createClient(t *testing.T) (*witApi.Client, *authApi.Client) {
 	c, err := wit.NewCachedClient(OpenshiftIOAPI)
 	if err != nil {
 		t.Fatal(err)
 	}
-	return c
+
+	authApi, err := auth.NewCachedClient(OpenShiftIOAuthAPI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return c, authApi
 }
 
 func TestWorkItem(t *testing.T) {
 
-	c := createClient(t)
+	witClient, authClient := createClient(t)
 	wiID, _ := uuid.FromString("8bccc228-bba7-43ad-b077-15fbb9148f7f")
 
-	users, vars, err := collector.WorkItem(context.Background(), c, wiID)
+	users, vars, err := collector.WorkItem(context.Background(), authClient, witClient, wiID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -51,10 +59,10 @@ func TestWorkItem(t *testing.T) {
 
 func TestComment(t *testing.T) {
 
-	c := createClient(t)
+	witClient, authClient := createClient(t)
 	cID, _ := uuid.FromString("5e7c1da9-af62-4b73-b18a-e88b7a6b9054")
 
-	users, vars, err := collector.Comment(context.Background(), c, cID)
+	users, vars, err := collector.Comment(context.Background(), authClient, witClient, cID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	yaml "gopkg.in/yaml.v2"
 
 	"github.com/spf13/viper"
@@ -17,6 +17,7 @@ const (
 	varHTTPAddress          = "http.address"
 	varDeveloperModeEnabled = "developer.mode.enabled"
 	varWITURL               = "wit.url"
+	varAuthURL              = "auth.url"
 	varMadrillAPIKey        = "mandrill.apikey"
 	varKeycloakRealm        = "keycloak.realm"
 	varKeycloakURL          = "keycloak.url"
@@ -77,6 +78,7 @@ func (c *Data) setConfigDefaults() {
 	c.v.SetDefault(varHTTPAddress, "0.0.0.0:8080")
 
 	c.v.SetDefault(varWITURL, defaultWITURL)
+	c.v.SetDefault(varAuthURL, defaultAuthURL)
 
 	//-----
 	// Misc
@@ -104,6 +106,11 @@ func (c *Data) IsDeveloperModeEnabled() bool {
 
 // GetWITURL return the base WorkItemTracker API URL
 func (c *Data) GetWITURL() string {
+	return c.v.GetString(varWITURL)
+}
+
+// GetAuthURL return the base Auth API URL
+func (c *Data) GetAuthURL() string {
 	return c.v.GetString(varWITURL)
 }
 
@@ -177,7 +184,8 @@ func (c *Data) Validate() error {
 }
 
 const (
-	defaultWITURL = "https://api.openshift.io/"
+	defaultWITURL  = "https://api.openshift.io/"
+	defaultAuthURL = "https://auth.openshift.io/"
 
 	// Auth-related defaults
 	defaultKeycloakURL   = "https://sso.prod-preview.openshift.io"

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -89,7 +89,9 @@ func (c *Data) setConfigDefaults() {
 	c.v.SetDefault(varLogLevel, defaultLogLevel)
 
 	c.v.SetDefault(varServiceAccountID, "4c34f6d4-f00b-487b-9a1f-e7d1adba6866")
-	c.v.SetDefault(varServiceAccountSecret, "notificationSecretNew")
+	c.v.SetDefault(varServiceAccountSecret, "secret")
+
+	// c.v.SetDefault(varMadrillAPIKey, "1234") // Enable for local testing.
 }
 
 // GetHTTPAddress returns the HTTP address (as set via default, config file, or environment variable)

--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -88,8 +88,8 @@ func (c *Data) setConfigDefaults() {
 	c.v.SetDefault(varDeveloperModeEnabled, false)
 	c.v.SetDefault(varLogLevel, defaultLogLevel)
 
-	c.v.SetDefault(varServiceAccountID, "4c83ca2d-6dcc-41c9-ac7d-b068ad4d17c5")
-	c.v.SetDefault(varServiceAccountSecret, "notificationsecret")
+	c.v.SetDefault(varServiceAccountID, "4c34f6d4-f00b-487b-9a1f-e7d1adba6866")
+	c.v.SetDefault(varServiceAccountSecret, "notificationSecretNew")
 }
 
 // GetHTTPAddress returns the HTTP address (as set via default, config file, or environment variable)
@@ -111,7 +111,7 @@ func (c *Data) GetWITURL() string {
 
 // GetAuthURL return the base Auth API URL
 func (c *Data) GetAuthURL() string {
-	return c.v.GetString(varWITURL)
+	return c.v.GetString(varAuthURL)
 }
 
 // GetServiceAccountID returns service account ID for the notification service.
@@ -185,7 +185,7 @@ func (c *Data) Validate() error {
 
 const (
 	defaultWITURL  = "https://api.openshift.io/"
-	defaultAuthURL = "https://auth.openshift.io/"
+	defaultAuthURL = "http://localhost:8089/"
 
 	// Auth-related defaults
 	defaultKeycloakURL   = "https://sso.prod-preview.openshift.io"

--- a/controller/notify_test.go
+++ b/controller/notify_test.go
@@ -9,12 +9,12 @@ import (
 
 	"github.com/fabric8-services/fabric8-notification/app"
 	"github.com/fabric8-services/fabric8-notification/app/test"
+	"github.com/fabric8-services/fabric8-notification/auth"
 	"github.com/fabric8-services/fabric8-notification/collector"
 	"github.com/fabric8-services/fabric8-notification/configuration"
 	"github.com/fabric8-services/fabric8-notification/email"
 	"github.com/fabric8-services/fabric8-notification/template"
 	"github.com/fabric8-services/fabric8-notification/validator"
-	"github.com/fabric8-services/fabric8-notification/wit"
 	"github.com/goadesign/goa"
 )
 
@@ -44,9 +44,9 @@ func TestNotifySendWithCustomParam(t *testing.T) {
 
 	resolvers := &collector.LocalRegistry{}
 	typeRegistry := &template.AssetRegistry{}
-	witClient, _ := wit.NewCachedClient(config.GetWITURL())
+	authClient, _ := auth.NewCachedClient(config.GetWITURL())
 
-	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(witClient)), validator.ValidateUser)
+	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(authClient)), validator.ValidateUser)
 	notifier := &email.CallbackNotifier{
 		Callback: func(ctx context.Context, notification email.Notification) {
 			require.NotNil(t, notification.CustomAttributes)
@@ -77,9 +77,9 @@ func TestNotifySendWithoutustomParamBadRequest(t *testing.T) {
 
 	resolvers := &collector.LocalRegistry{}
 	typeRegistry := &template.AssetRegistry{}
-	witClient, _ := wit.NewCachedClient(config.GetWITURL())
+	authClient, _ := auth.NewCachedClient(config.GetWITURL())
 
-	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(witClient)), validator.ValidateUser)
+	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(authClient)), validator.ValidateUser)
 	notifier := &email.CallbackNotifier{
 		Callback: func(ctx context.Context, notification email.Notification) {
 			require.NotNil(t, notification.CustomAttributes)
@@ -107,9 +107,9 @@ func TestNotifySendWithCustomParamBadRequest(t *testing.T) {
 
 	resolvers := &collector.LocalRegistry{}
 	typeRegistry := &template.AssetRegistry{}
-	witClient, _ := wit.NewCachedClient(config.GetWITURL())
+	authClient, _ := auth.NewCachedClient(config.GetWITURL())
 
-	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(witClient)), validator.ValidateUser)
+	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(authClient)), validator.ValidateUser)
 	notifier := &email.CallbackNotifier{
 		Callback: func(ctx context.Context, notification email.Notification) {
 			require.NotNil(t, notification.CustomAttributes)
@@ -140,9 +140,9 @@ func TestNotifySendWithoutCustomParamSuccess(t *testing.T) {
 
 	resolvers := &collector.LocalRegistry{}
 	typeRegistry := &template.AssetRegistry{}
-	witClient, _ := wit.NewCachedClient(config.GetWITURL())
+	authClient, _ := auth.NewCachedClient(config.GetWITURL())
 
-	resolvers.Register("workitem.update", collector.ConfiguredVars(config, collector.NewUserResolver(witClient)), nil)
+	resolvers.Register("workitem.update", collector.ConfiguredVars(config, collector.NewUserResolver(authClient)), nil)
 	notifier := &email.CallbackNotifier{
 		Callback: func(ctx context.Context, notification email.Notification) {
 		}}

--- a/glide.lock
+++ b/glide.lock
@@ -1,10 +1,12 @@
-hash: f875c6dfb774e9364c3caa3ae098a5d75d65afc04a69d4d05e2a11893791a571
-updated: 2017-08-24T05:24:29.31397775+02:00
+hash: 5ca475c05c90b09f3ad15fbb5c573ec32a4dac9929b430356b370bbbcc8381d2
+updated: 2018-01-08T17:36:06.215808867+05:30
 imports:
+- name: github.com/ajg/form
+  version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
 - name: github.com/armon/go-metrics
-  version: 97c69685293dce4c0a2d0b19535179bbc976e4d2
+  version: 9a4b6e10bed6220a1665955aa2b75afc91eb10b3
 - name: github.com/dgrijalva/jwt-go
-  version: d2709f9f1f31ebcda9651b03077758c1f3a0018c
+  version: dbeaa9332f19a944acb5736b4456cfcc02140e29
 - name: github.com/dimfeld/httppath
   version: c8e499c3ef3c3e272ed8bdcc1ccf39f73c88debc
 - name: github.com/dimfeld/httptreemux
@@ -13,8 +15,12 @@ imports:
   version: 9a6736ed45b44bf3835afeebb3034b57ed329f3e
   subpackages:
   - go-bindata-assetfs
+- name: github.com/fabric8-services/fabric8-auth
+  version: f67317193c3108895f853f80f9330c1a65b11004
+  subpackages:
+  - design
 - name: github.com/fabric8-services/fabric8-wit
-  version: 58db841e76891f1251bdec86908c61360f11d375
+  version: ff1746954f6c1a89dc2c35b72731e19b63d842d2
   subpackages:
   - configuration
   - design
@@ -29,7 +35,7 @@ imports:
 - name: github.com/fsnotify/fsnotify
   version: 629574ca2a5df945712d3079857300b5e4da0236
 - name: github.com/goadesign/goa
-  version: 58f3177f36f2c50ee6119da92795e48bac6d6243
+  version: 5646a430cdeb66983d5ace3384e0a667c185abc7
   vcs: git
   subpackages:
   - client
@@ -37,6 +43,7 @@ imports:
   - design
   - design/apidsl
   - dslengine
+  - encoding/form
   - goagen
   - goagen/codegen
   - goagen/gen_app
@@ -50,6 +57,12 @@ imports:
   - uuid
 - name: github.com/gregjones/httpcache
   version: 0d2297f241a3503b4d464cd434e6d1490ec76e9a
+- name: github.com/hashicorp/go-immutable-radix
+  version: 8aac2701530899b64bdea735a1de8da899815220
+- name: github.com/hashicorp/golang-lru
+  version: 0a025b7e63adc15a622f29b0b2c4c3848243bbf6
+  subpackages:
+  - simplelru
 - name: github.com/hashicorp/hcl
   version: 37ab263305aaeb501a60eb16863e808d426e37f2
   subpackages:
@@ -68,7 +81,7 @@ imports:
 - name: github.com/lib/pq
   version: 4a82388ebc5138c8289fe9bc602cb0b3e32cd617
 - name: github.com/magiconair/properties
-  version: be5ece7dd465ab0765a9682137865547526d1dfb
+  version: d419a98cdbed11a922bf76f257b7c4be79b50e73
 - name: github.com/manveru/faker
   version: 717f7cf83fb78669bfab612749c2e8ff63d5be11
 - name: github.com/mattbaird/gochimp
@@ -83,7 +96,7 @@ imports:
   version: 645ef00459ed84a119197bfb8d8205042c6df63d
 - name: github.com/satori/go.uuid
   version: b061729afc07e77a8aa4fad0a2fd840958f1942a
-- name: github.com/Sirupsen/logrus
+- name: github.com/sirupsen/logrus
   version: c078b1e43f58d563c74cebe63c85789e76ddb627
 - name: github.com/spf13/afero
   version: 2f30b2a92c0e5700bcfe4715891adb1f2a7a406d

--- a/glide.yaml
+++ b/glide.yaml
@@ -2,7 +2,7 @@ package: github.com/fabric8-services/fabric8-notification
 license: Apache-2.0
 import:
 - package: github.com/fabric8-services/fabric8-wit
-  version: 58db841e76891f1251bdec86908c61360f11d375
+  version: ff1746954f6c1a89dc2c35b72731e19b63d842d2
   subpackages:
     - log
     - errors
@@ -11,6 +11,10 @@ import:
     - jsonapi
     - design
     - goasupport
+- package: github.com/fabric8-services/fabric8-auth
+  version: f67317193c3108895f853f80f9330c1a65b11004
+  subpackages:
+    - design
 - package: github.com/gregjones/httpcache
 - package: github.com/mattbaird/gochimp
 - package: github.com/goadesign/goa
@@ -34,7 +38,7 @@ import:
 - package: github.com/zach-klippenstein/goregen
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
-- package: github.com/Sirupsen/logrus
+- package: github.com/sirupsen/logrus
 - package: github.com/lib/pq
 - package: gopkg.in/yaml.v2
 - package: github.com/jteeuwen/go-bindata

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"github.com/fabric8-services/fabric8-notification/auth"
 	"github.com/fabric8-services/fabric8-notification/collector"
 	goaclient "github.com/goadesign/goa/client"
-	"github.com/goadesign/goa/uuid"
 
 	"github.com/fabric8-services/fabric8-notification/configuration"
 	"github.com/fabric8-services/fabric8-notification/controller"

--- a/main.go
+++ b/main.go
@@ -93,8 +93,7 @@ func main() {
 		log.Panic(nil, map[string]interface{}{
 			"err": err,
 		}, "Could not create Madrill Sender")
-	}	goaclient "github.com/goadesign/goa/client"
-	
+	}
 
 	notifier := email.NewAsyncWorkerNotifier(sender, 1)
 

--- a/main.go
+++ b/main.go
@@ -93,7 +93,8 @@ func main() {
 		log.Panic(nil, map[string]interface{}{
 			"err": err,
 		}, "Could not create Madrill Sender")
-	}
+	}	goaclient "github.com/goadesign/goa/client"
+	
 
 	notifier := email.NewAsyncWorkerNotifier(sender, 1)
 

--- a/main.go
+++ b/main.go
@@ -77,18 +77,23 @@ func main() {
 		}, "Could not create Auth client")
 	}
 
+	// using a saService here with the plan to pass it to controllers
+	// in future.
 	saService := token.NewFabric8ServiceAccountTokenClient(authClient, config.GetServiceAccountID(), config.GetServiceAccountSecret())
 	saToken, err := saService.Get(context.Background())
+	if err != nil {
+		log.Panic(nil, map[string]interface{}{
+			"err": err,
+		}, "could not generate service account token")
+	}
 
 	authClient.SetJWTSigner(&goaclient.JWTSigner{
 		TokenSource: &goaclient.StaticTokenSource{
 			StaticToken: &goaclient.StaticToken{
-				Value: saToken,
+				Value: saToken, // TODO: How do we handle expiry of this token ?
 			},
 		},
 	})
-
-	// TODO: How do we handle expiry of this token ?
 
 	sender, err := email.NewMandrillSender(config.GetMadrillAPIKey())
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"context"
-	goaclient "github.com/goadesign/goa/client"
 	"net/http"
 
 	"github.com/fabric8-services/fabric8-notification/app"
@@ -69,12 +68,12 @@ func main() {
 		}, "Could not create WIT client")
 	}
 
-	authClient, err := auth.NewCachedClient(config.GetWITURL())
+	authClient, err := auth.NewCachedClient(config.GetAuthURL())
 	if err != nil {
 		log.Panic(nil, map[string]interface{}{
-			"url": config.GetWITURL(),
+			"url": config.GetAuthURL(),
 			"err": err,
-		}, "Could not create Auth client")
+		}, "could not create Auth client")
 	}
 
 	// using a saService here with the plan to pass it to controllers
@@ -87,13 +86,7 @@ func main() {
 		}, "could not generate service account token")
 	}
 
-	authClient.SetJWTSigner(&goaclient.JWTSigner{
-		TokenSource: &goaclient.StaticTokenSource{
-			StaticToken: &goaclient.StaticToken{
-				Value: saToken, // TODO: How do we handle expiry of this token ?
-			},
-		},
-	})
+	authClient, err = auth.SecureClient(authClient, saToken)
 
 	sender, err := email.NewMandrillSender(config.GetMadrillAPIKey())
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -88,7 +88,7 @@ func main() {
 	resolvers.Register("workitem.update", collector.ConfiguredVars(config, collector.NewWorkItemResolver(authClient, witClient)), nil)
 	resolvers.Register("comment.create", collector.ConfiguredVars(config, collector.NewCommentResolver(authClient, witClient)), nil)
 	resolvers.Register("comment.update", collector.ConfiguredVars(config, collector.NewCommentResolver(authClient, witClient)), nil)
-	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(witClient)), validator.ValidateUser)
+	resolvers.Register("user.email.update", collector.ConfiguredVars(config, collector.NewUserResolver(authClient)), validator.ValidateUser)
 
 	typeRegistry := &template.AssetRegistry{}
 	service := goa.New("notification")

--- a/preview/main.go
+++ b/preview/main.go
@@ -75,7 +75,7 @@ func generate(authClient *authapi.Client, c *api.Client, id, tmplName string) er
 	} else if strings.HasPrefix(tmplName, "comment") {
 		_, vars, err = collector.Comment(context.Background(), authClient, c, wiID)
 	} else if strings.HasPrefix(tmplName, "user") {
-		_, vars, err = collector.User(context.Background(), c, wiID)
+		_, vars, err = collector.User(context.Background(), authClient, wiID)
 		vars["custom"] = map[string]interface{}{
 			"verifyURL": "https://auth.openshift.io?verify",
 		}

--- a/preview/main.go
+++ b/preview/main.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/fabric8-services/fabric8-notification/auth"
+	authapi "github.com/fabric8-services/fabric8-notification/auth/api"
 	"github.com/fabric8-services/fabric8-notification/collector"
 	"github.com/fabric8-services/fabric8-notification/template"
 	"github.com/fabric8-services/fabric8-notification/wit"
@@ -16,11 +18,13 @@ import (
 )
 
 const (
-	OpenshiftIOAPI = "https://api.openshift.io"
+	OpenshiftIOAPI     = "https://api.openshift.io"
+	AuthOpenShiftIOAPI = "https://auth.openshift.io"
 )
 
 func main() {
 	c, err := wit.NewCachedClient(OpenshiftIOAPI)
+	authClient, err := auth.NewCachedClient(OpenshiftIOAPI)
 	if err != nil {
 		panic(err)
 	}
@@ -46,14 +50,14 @@ func main() {
 	fmt.Println("")
 
 	for _, d := range testdata {
-		err = generate(c, d.id, d.templateName)
+		err = generate(authClient, c, d.id, d.templateName)
 		if err != nil {
 			fmt.Printf(err.Error())
 		}
 	}
 }
 
-func generate(c *api.Client, id, tmplName string) error {
+func generate(authClient *authapi.Client, c *api.Client, id, tmplName string) error {
 	reg := template.AssetRegistry{}
 
 	temp, exist := reg.Get(tmplName)
@@ -67,9 +71,9 @@ func generate(c *api.Client, id, tmplName string) error {
 	var err error
 
 	if strings.HasPrefix(tmplName, "workitem") {
-		_, vars, err = collector.WorkItem(context.Background(), c, wiID)
+		_, vars, err = collector.WorkItem(context.Background(), authClient, c, wiID)
 	} else if strings.HasPrefix(tmplName, "comment") {
-		_, vars, err = collector.Comment(context.Background(), c, wiID)
+		_, vars, err = collector.Comment(context.Background(), authClient, c, wiID)
 	} else if strings.HasPrefix(tmplName, "user") {
 		_, vars, err = collector.User(context.Background(), c, wiID)
 		vars["custom"] = map[string]interface{}{

--- a/template/template_func.go
+++ b/template/template_func.go
@@ -6,7 +6,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/fabric8-services/fabric8-notification/wit/api"
+	authapi "github.com/fabric8-services/fabric8-notification/auth/api"
+	witapi "github.com/fabric8-services/fabric8-notification/wit/api"
 )
 
 func formatDate(date interface{}) string {
@@ -51,7 +52,7 @@ func resolveString(data interface{}) string {
 	return fmt.Sprint(data)
 }
 
-func detailURL(webURL string, spaceOwner api.User, space api.SpaceSingle, workitem api.WorkItemSingle) string {
+func detailURL(webURL string, spaceOwner *authapi.User, space witapi.SpaceSingle, workitem witapi.WorkItemSingle) string {
 	return fmt.Sprintf(
 		"%v/%v/%v/plan/detail/%v",
 		webURL,

--- a/token/service_account.go
+++ b/token/service_account.go
@@ -1,0 +1,33 @@
+package token
+
+import (
+	"context"
+	"github.com/fabric8-services/fabric8-notification/auth"
+	"github.com/fabric8-services/fabric8-notification/auth/api"
+)
+
+type Fabric8ServiceAccountTokenClient struct {
+	client        *api.Client
+	accountID     string
+	accountSecret string
+}
+
+func NewFabric8ServiceAccountTokenClient(client *api.Client, accountID string, accountSecret string) *Fabric8ServiceAccountTokenClient {
+	return &Fabric8ServiceAccountTokenClient{
+		client:        client,
+		accountID:     accountID,
+		accountSecret: accountSecret,
+	}
+}
+
+type Fabric8ServiceAccountTokenService interface {
+	Get(ctx context.Context) (string, error)
+}
+
+func (c *Fabric8ServiceAccountTokenClient) Get(ctx context.Context) (string, error) {
+	tokenString, err := auth.GetServiceAccountToken(ctx, c.client, c.accountID, c.accountSecret)
+	if err != nil {
+		return "", err
+	}
+	return *tokenString.AccessToken, nil
+}

--- a/token/service_account.go
+++ b/token/service_account.go
@@ -39,10 +39,10 @@ func (c *Fabric8ServiceAccountTokenClient) Get(ctx context.Context) (string, err
 	if tokenString == nil {
 		return "", errs.NewInternalError(ctx, errors.New("couldn't generate service account token"))
 	}
-	return *tokenString.AccessToken, nil
+	return tokenString.AccessToken, nil
 }
 
-func getServiceAccountToken(ctx context.Context, client *api.Client, serviceAccountID string, serviceAccountSecret string) (*api.OauthToken, error) {
+func getServiceAccountToken(ctx context.Context, client *api.Client, serviceAccountID string, serviceAccountSecret string) (*api.ExternalToken, error) {
 	payload := api.TokenExchange{
 		ClientID:     serviceAccountID,
 		ClientSecret: &serviceAccountSecret,
@@ -61,6 +61,6 @@ func getServiceAccountToken(ctx context.Context, client *api.Client, serviceAcco
 		return nil, err
 	}
 
-	return client.DecodeOauthToken(resp)
+	return client.DecodeExternalToken(resp)
 
 }

--- a/wit/client.go
+++ b/wit/client.go
@@ -30,22 +30,6 @@ func NewCachedClient(hostURL string) (*api.Client, error) {
 	return c, nil
 }
 
-func GetUser(ctx context.Context, client *api.Client, uID uuid.UUID) (*api.User, error) {
-	resp, err := client.ShowUsers(goasupport.ForwardContextRequestID(ctx), api.ShowUsersPath(uID.String()))
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET user", resp.StatusCode)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	return client.DecodeUser(resp)
-}
-
 func GetWorkItem(ctx context.Context, client *api.Client, wiID uuid.UUID) (*api.WorkItemSingle, error) {
 	resp, err := client.ShowWorkitem(goasupport.ForwardContextRequestID(ctx), api.ShowWorkitemPath(wiID), nil, nil)
 	if resp != nil {

--- a/wit/client.go
+++ b/wit/client.go
@@ -31,7 +31,7 @@ func NewCachedClient(hostURL string) (*api.Client, error) {
 }
 
 func GetUser(ctx context.Context, client *api.Client, uID uuid.UUID) (*api.User, error) {
-	resp, err := client.ShowUsers(goasupport.ForwardContextRequestID(ctx), api.ShowUsersPath(uID.String()), nil, nil)
+	resp, err := client.ShowUsers(goasupport.ForwardContextRequestID(ctx), api.ShowUsersPath(uID.String()))
 	if resp != nil {
 		defer resp.Body.Close()
 	}
@@ -143,22 +143,4 @@ func GetSpace(ctx context.Context, client *api.Client, spaceID uuid.UUID) (*api.
 		return nil, err
 	}
 	return client.DecodeSpaceSingle(resp)
-}
-
-func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid.UUID) (*api.UserList, error) {
-	pageLimit := 100
-	pageOffset := "0"
-	resp, err := client.ListCollaborators(goasupport.ForwardContextRequestID(ctx), api.ListCollaboratorsPath(spaceID), &pageLimit, &pageOffset, nil, nil)
-	if resp != nil {
-		defer resp.Body.Close()
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET collaborators", resp.StatusCode)
-	}
-
-	if err != nil {
-		return nil, err
-	}
-	return client.DecodeUserList(resp)
 }

--- a/wit/client_test.go
+++ b/wit/client_test.go
@@ -22,6 +22,7 @@ func createClient(t *testing.T) *api.Client {
 	return c
 }
 
+/*
 func TestGetUser(t *testing.T) {
 
 	c := createClient(t)
@@ -34,6 +35,7 @@ func TestGetUser(t *testing.T) {
 
 	assert.Equal(t, "aslak@redhat.com", *u.Data.Attributes.Email)
 }
+*/
 
 func TestWorkItem(t *testing.T) {
 

--- a/wit/client_test.go
+++ b/wit/client_test.go
@@ -11,11 +11,11 @@ import (
 )
 
 const (
-	OpenshiftIOAPI = "http://api.openshift.io"
+	openshiftIOAPI = "http://api.openshift.io"
 )
 
 func createClient(t *testing.T) *api.Client {
-	c, err := wit.NewCachedClient(OpenshiftIOAPI)
+	c, err := wit.NewCachedClient(openshiftIOAPI)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -98,17 +98,4 @@ func TestSpace(t *testing.T) {
 	}
 
 	assert.Equal(t, "openshiftio", *u.Data.Attributes.Name)
-}
-
-func TestSpaceCollaborators(t *testing.T) {
-
-	c := createClient(t)
-	id, _ := uuid.FromString("020f756e-b51a-4b43-b113-45cec16b9ce9")
-
-	u, err := wit.GetSpaceCollaborators(context.Background(), c, id)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.True(t, len(u.Data) > 10)
 }

--- a/wit/client_test.go
+++ b/wit/client_test.go
@@ -22,32 +22,17 @@ func createClient(t *testing.T) *api.Client {
 	return c
 }
 
-/*
-func TestGetUser(t *testing.T) {
-
-	c := createClient(t)
-	ID, err := uuid.FromString("b67f1cee-0a9f-40da-8e52-504c092e54e0")
-
-	u, err := wit.GetUser(context.Background(), c, ID)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	assert.Equal(t, "aslak@redhat.com", *u.Data.Attributes.Email)
-}
-*/
-
 func TestWorkItem(t *testing.T) {
 
 	c := createClient(t)
-	ID, err := uuid.FromString("8bccc228-bba7-43ad-b077-15fbb9148f7f")
+	ID, err := uuid.FromString("4728edab-6ccb-4c99-bd4c-f4aeabc560ad")
 
 	u, err := wit.GetWorkItem(context.Background(), c, ID)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	assert.Equal(t, "Cannot resolve Area/Iteration info for new WI created in in-memory mode", u.Data.Attributes["system.title"])
+	assert.Equal(t, "The default workitem type for inline quick-add in Experiences context is set to Bug instead of Feature", u.Data.Attributes["system.title"])
 }
 
 func TestArea(t *testing.T) {


### PR DESCRIPTION
Notification service would talk to Auth using the service account to get the user info - that will ensure that notification services gets to 'see' the email address even if the user has made it private.
  

- [x] Update dependencies & take in the latest Auth client.
- [x] fix existing tests.
- [x] Consume the client to talk to Auth to get the service account token.
- [x] use the Service account token to call the Auth user API.
- [x] update openshift config map https://github.com/fabric8-services/fabric8-notification/pull/56  
- [x] update staging/prod with config map values https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1059

Note:
The `ShowUser(..)` client method now has some special treatment.
The general `https://auth.openshift.io/api/users/:ID` does not ask for an authorization header with jwt, but we've added support on the auth side [1] to check for service tokens and override email privacy. Since this is not part of auth's `design/account.go` , the autogenerated goa auth client doesn't respect the token. 
Therefore, I've added custom http client calls to handle the /api/users/ID.


[1] https://github.com/fabric8-services/fabric8-auth/commit/ffb7c613b5331f66686ac4d9a4b09b8cce167b57#diff-da062b312519ee2a61dd669f1ec964d4R70

fixes https://github.com/fabric8-services/fabric8-notification/issues/52
part of https://github.com/fabric8-services/fabric8-auth/issues/241