### PR TITLE
Support workitem-related notifications for private emails

### DIFF
--- a/auth/client.go
+++ b/auth/client.go
@@ -1,16 +1,11 @@
 package auth
 
 import (
-	"context"
 	"net/http"
 	"net/url"
 
-	"fmt"
-
 	"github.com/fabric8-services/fabric8-notification/auth/api"
-	"github.com/fabric8-services/fabric8-wit/goasupport"
 	goaclient "github.com/goadesign/goa/client"
-	"github.com/goadesign/goa/uuid"
 	"github.com/gregjones/httpcache"
 )
 
@@ -28,23 +23,4 @@ func NewCachedClient(hostURL string) (*api.Client, error) {
 	c.Host = u.Host
 	c.Scheme = u.Scheme
 	return c, nil
-}
-
-func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid.UUID) (*api.UserList, error) {
-	pageLimit := 100
-	pageOffset := "0"
-	resp, err := client.ListCollaborators(goasupport.ForwardContextRequestID(ctx), api.ListCollaboratorsPath(spaceID), &pageLimit, &pageOffset, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-	if resp != nil {
-		defer resp.Body.Close()
-	} else {
-		return nil, fmt.Errorf("failed to make request to get list of collaborators")
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET collaborators", resp.StatusCode)
-	}
-	return client.DecodeUserList(resp)
 }

--- a/auth/client_test.go
+++ b/auth/client_test.go
@@ -2,6 +2,7 @@ package auth_test
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-notification/auth"
@@ -31,6 +32,16 @@ func TestSpaceCollaborators(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
 	assert.True(t, len(u.Data) > 10)
+
+	// there is no easy way to test if the sa token really gets to override the privacy of emails.
+	// the following lines only checks whether the emails show up at all if privacy is set to true
+	for _, user := range u.Data {
+		require.NotNil(t, user.Attributes.Email)
+		if user.Attributes.EmailPrivate != nil && *user.Attributes.EmailPrivate {
+			assert.Empty(t, *user.Attributes.Email)
+		} else {
+			assert.NotEmpty(t, *user.Attributes.Email)
+		}
+	}
 }

--- a/auth/space_collaborators_client.go
+++ b/auth/space_collaborators_client.go
@@ -1,0 +1,82 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/url"
+
+	"fmt"
+	"strconv"
+
+	"github.com/fabric8-services/fabric8-notification/auth/api"
+	"github.com/fabric8-services/fabric8-wit/goasupport"
+	"github.com/goadesign/goa/uuid"
+)
+
+func GetSpaceCollaborators(ctx context.Context, client *api.Client, spaceID uuid.UUID) (*api.UserList, error) {
+	pageLimit := 100
+	pageOffset := "0"
+	resp, err := listCollaborators(goasupport.ForwardContextRequestID(ctx), client, api.ListCollaboratorsPath(spaceID), &pageLimit, &pageOffset, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	if resp != nil {
+		defer resp.Body.Close()
+	} else {
+		return nil, fmt.Errorf("failed to make request to get list of collaborators")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non %v status code for %v, returned %v", http.StatusOK, "GET collaborators", resp.StatusCode)
+	}
+	return client.DecodeUserList(resp)
+}
+
+// list collaborators for the given space ID.
+func listCollaborators(ctx context.Context, client *api.Client, path string, pageLimit *int, pageOffset *string, ifModifiedSince *string, ifNoneMatch *string) (*http.Response, error) {
+	req, err := newListCollaboratorsRequest(ctx, client, path, pageLimit, pageOffset, ifModifiedSince, ifNoneMatch)
+	if err != nil {
+		return nil, err
+	}
+	return client.Do(ctx, req)
+}
+
+// newListCollaboratorsRequest create the request corresponding to the list action endpoint of the collaborators resource.
+func newListCollaboratorsRequest(ctx context.Context, client *api.Client, path string, pageLimit *int, pageOffset *string, ifModifiedSince *string, ifNoneMatch *string) (*http.Request, error) {
+	scheme := client.Scheme
+	if scheme == "" {
+		scheme = "http"
+	}
+	u := url.URL{Host: client.Host, Scheme: scheme, Path: path}
+	values := u.Query()
+	if pageLimit != nil {
+		tmp3 := strconv.Itoa(*pageLimit)
+		values.Set("page[limit]", tmp3)
+	}
+	if pageOffset != nil {
+		values.Set("page[offset]", *pageOffset)
+	}
+	u.RawQuery = values.Encode()
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+	header := req.Header
+	if ifModifiedSince != nil {
+
+		header.Set("If-Modified-Since", *ifModifiedSince)
+	}
+	if ifNoneMatch != nil {
+
+		header.Set("If-None-Match", *ifNoneMatch)
+	}
+
+	// This wasn't present in the auto-generated client for GET /api/spaces/ID/collaborators/ID
+	// because we don't set "a.Security("jwt")" in auth's design/account.go
+	// for the `List Collaborators` action.
+	if client.JWTSigner != nil {
+		client.JWTSigner.Sign(req)
+	}
+
+	return req, nil
+}


### PR DESCRIPTION
- Use Service account token for calling List Collaborators API
- Re-wrote the http-related code to call the List Collaborators API in order to pass the token even though the API doesn't ask for a JWT by design.
