### PR TITLE
fix(packages): fix package error on build

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -39,6 +39,11 @@ import:
 - package: github.com/spf13/cobra
 - package: github.com/spf13/viper
 - package: github.com/sirupsen/logrus
+  version: master
+- package: github.com/Sirupsen/logrus
+  repo: git@github.com:/sirupsen/logrus
+  vcs: git
+  version: master
 - package: github.com/lib/pq
 - package: gopkg.in/yaml.v2
 - package: github.com/jteeuwen/go-bindata


### PR DESCRIPTION
This fixes a package error due to a name change on the sirupsen/logrus package. Package could not longer be found under old name.