### PR TITLE
Move to Quay.io

### DIFF
--- a/Dockerfile.deploy.rhel
+++ b/Dockerfile.deploy.rhel
@@ -1,4 +1,5 @@
-FROM prod.registry.devshift.net/osio-prod/base/pcp:latest
+FROM quay.io/openshiftio/rhel-base-pcp:latest
+
 LABEL maintainer "Devtools <devtools@redhat.com>"
 LABEL author "Devtools <devtools@redhat.com>"
 ENV LANG=en_US.utf8

--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -111,6 +111,6 @@ objects:
       deploymentconfig: f8notification
 parameters:
 - name: IMAGE
-  value: registry.devshift.net/fabric8-services/fabric8-notification
+  value: quay.io/openshiftio/fabric8-services-fabric8-notification
 - name: IMAGE_TAG
   value: latest

--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -111,6 +111,6 @@ objects:
       deploymentconfig: f8notification
 parameters:
 - name: IMAGE
-  value: quay.io/openshiftio/fabric8-services-fabric8-notification
+  value: quay.io/openshiftio/rhel-fabric8-services-fabric8-notification
 - name: IMAGE_TAG
   value: latest


### PR DESCRIPTION
This PR is part of the effort to move to Quay.

This is the list of changes in this PR:

- Pushes to Quay instead of the Devshift registry
- Uses an image hosted in Quay to build the RHEL based container image
- Uses the new env-toolkit to load variables from jenkins-env
- Changes the default path of the image to quay (note that this should not affect production because it is overridden in the saas repo)

A companion PR should have been submitted to the appropriate saas repo to change the staging url from devshift to quay. The PR to the saas repo should be merged before this one.

Companion PR: https://github.com/openshiftio/saas-openshiftio/pull/911