### PR TITLE
fetch keys from auth service

### DIFF
--- a/configuration/configuration.go
+++ b/configuration/configuration.go
@@ -20,8 +20,6 @@ const (
 	varWITURL               = "wit.url"
 	varAuthURL              = "auth.url"
 	varMadrillAPIKey        = "mandrill.apikey"
-	varKeycloakRealm        = "keycloak.realm"
-	varKeycloakURL          = "keycloak.url"
 	varLogLevel             = "log.level"
 	varLogJSON              = "log.json"
 	varServiceAccountID     = "service.account.id"
@@ -148,28 +146,6 @@ func (c *Data) GetMadrillAPIKey() string {
 	return c.v.GetString(varMadrillAPIKey)
 }
 
-// GetKeycloakRealm returns the keyclaok realm name
-func (c *Data) GetKeycloakRealm() string {
-	if c.v.IsSet(varKeycloakRealm) {
-		return c.v.GetString(varKeycloakRealm)
-	}
-	if c.IsDeveloperModeEnabled() {
-		return devModeKeycloakRealm
-	}
-	return defaultKeycloakRealm
-}
-
-// GetKeycloakURL returns Keycloak URL used by default in Dev mode
-func (c *Data) GetKeycloakURL() string {
-	if c.v.IsSet(varKeycloakURL) {
-		return c.v.GetString(varKeycloakURL)
-	}
-	if c.IsDeveloperModeEnabled() {
-		return devModeKeycloakURL
-	}
-	return defaultKeycloakURL
-}
-
 // GetLogLevel returns the loggging level (as set via config file or environment variable)
 func (c *Data) GetLogLevel() string {
 	return c.v.GetString(varLogLevel)
@@ -194,16 +170,7 @@ func (c *Data) Validate() error {
 }
 
 const (
-	defaultWITURL  = "https://api.openshift.io/"
-	defaultAuthURL = "http://localhost:8089/"
-
-	// Auth-related defaults
-	defaultKeycloakURL   = "https://sso.prod-preview.openshift.io"
-	defaultKeycloakRealm = "fabric8"
-
-	// Keycloak vars to be used in dev mode. Can be overridden by setting up keycloak.url & keycloak.realm
-	devModeKeycloakURL   = "https://sso.prod-preview.openshift.io"
-	devModeKeycloakRealm = "fabric8-test"
-
+	defaultWITURL   = "https://api.openshift.io/"
+	defaultAuthURL  = "http://localhost:8089/"
 	defaultLogLevel = "info"
 )

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 3cd9506a5157d3b749ea15d96743d5fabe9acf42a6d77ecb00ca482c9c4f024a
-updated: 2018-04-27T17:49:43.403266672+02:00
+hash: 1286c7ed7350e6808f0dcda3b67fb1831fc544956decd5ab8b658c7062f93bc1
+updated: 2018-07-02T21:50:50.686865538+05:30
 imports:
 - name: github.com/ajg/form
   version: cc2954064ec9ea8d93917f0f87456e11d7b881ad
@@ -20,7 +20,7 @@ imports:
   subpackages:
   - go-bindata-assetfs
 - name: github.com/fabric8-services/fabric8-auth
-  version: f67317193c3108895f853f80f9330c1a65b11004
+  version: 81bf87a6bdae7528a88041f0493555a9fd45a847
   subpackages:
   - design
 - name: github.com/fabric8-services/fabric8-wit
@@ -163,11 +163,11 @@ imports:
   version: a888bfdffa4526cc6987572bca9a2c6b7758290f
   subpackages:
   - go/ast/astutil
+- name: gopkg.in/square/go-jose.v2
+  version: 552e98edab5d620205ff1a8960bf52a5a10aad03
 - name: gopkg.in/yaml.v2
   version: a5b47d31c556af34a302ce5d659e6fea44d90de0
 testImports:
-- name: github.com/corpix/uarand
-  version: 2b8494104d86337cdd41d0a49cbed8e4583c0ab4
 - name: github.com/davecgh/go-spew
   version: adab96458c51a58dc1783b3335dcce5461522e75
   subpackages:
@@ -178,8 +178,6 @@ testImports:
   version: c7bacac2b21ca01afa1dee0acf64df3ce047c28f
   subpackages:
   - golint
-- name: github.com/icrowley/fake
-  version: e64cc2cf92049a299f359734c6ea76073f2a8b2c
 - name: github.com/jstemmer/go-junit-report
   version: 15422cf504f9dc030386499a5c68053a38763e58
 - name: github.com/pmezard/go-difflib

--- a/glide.yaml
+++ b/glide.yaml
@@ -4,17 +4,18 @@ import:
 - package: github.com/fabric8-services/fabric8-wit
   version: 8e74c765391d51a548ffb351038c32fe932398d9
   subpackages:
-    - log
-    - errors
-    - login/token_context
-    - resource
-    - jsonapi
-    - design
-    - goasupport
+  - log
+  - errors
+  - login/token_context
+  - resource
+  - jsonapi
+  - design
+  - goasupport
 - package: github.com/fabric8-services/fabric8-auth
-  version: f67317193c3108895f853f80f9330c1a65b11004
+  version: 81bf87a6bdae7528a88041f0493555a9fd45a847
   subpackages:
-    - design
+  - design
+  - token/jwk
 - package: github.com/gregjones/httpcache
 - package: github.com/mattbaird/gochimp
 - package: github.com/goadesign/goa
@@ -55,12 +56,13 @@ import:
   version: v1.2.0
 - package: github.com/magiconair/properties
 - package: github.com/prometheus/client_golang
+- package: gopkg.in/square/go-jose.v2
 testImport:
 - package: github.com/wadey/gocovmerge
 - package: github.com/jstemmer/go-junit-report
 - package: github.com/stretchr/testify
   subpackages:
-    - assert
+  - assert
 - package: github.com/golang/lint
   subpackages:
   - golint

--- a/main.go
+++ b/main.go
@@ -14,7 +14,6 @@ import (
 	"github.com/fabric8-services/fabric8-notification/controller"
 	"github.com/fabric8-services/fabric8-notification/email"
 	"github.com/fabric8-services/fabric8-notification/jsonapi"
-	"github.com/fabric8-services/fabric8-notification/keycloak"
 	"github.com/fabric8-services/fabric8-notification/template"
 	"github.com/fabric8-services/fabric8-notification/token"
 	"github.com/fabric8-services/fabric8-notification/validator"
@@ -44,16 +43,11 @@ func main() {
 	// Initialized developer mode flag for the logger
 	log.InitializeLogger(config.IsLogJSON(), config.GetLogLevel())
 
-	keycloakConfig := keycloak.Config{
-		BaseURL: config.GetKeycloakURL(),
-		Realm:   config.GetKeycloakRealm(),
-	}
-
-	publicKey, err := keycloak.GetPublicKey(keycloakConfig)
+	tokenManager, err := token.NewManager(config)
 	if err != nil {
 		log.Panic(nil, map[string]interface{}{
 			"err": err,
-		}, "failed to parse public token")
+		}, "failed to create token manager")
 	}
 
 	err = config.Validate()
@@ -125,9 +119,9 @@ func main() {
 	service.Use(jsonapi.ErrorHandler(service, true))
 	service.Use(middleware.Recover())
 
-	service.Use(witmiddleware.TokenContext(publicKey, nil, app.NewJWTSecurity()))
+	service.Use(witmiddleware.TokenContext(tokenManager.PublicKeys(), nil, app.NewJWTSecurity()))
 	service.Use(log.LogRequest(config.IsDeveloperModeEnabled()))
-	app.UseJWTMiddleware(service, goajwt.New(publicKey, nil, app.NewJWTSecurity()))
+	app.UseJWTMiddleware(service, goajwt.New(tokenManager.PublicKeys(), nil, app.NewJWTSecurity()))
 
 	// Mount "status" controller
 	statusCtrl := controller.NewStatusController(service)

--- a/openshift/OpenShiftTemplate.yml
+++ b/openshift/OpenShiftTemplate.yml
@@ -47,16 +47,6 @@ objects:
               configMapKeyRef:
                 name: f8notification
                 key: auth.url
-          - name: F8_KEYCLOAK_URL
-            valueFrom:
-              configMapKeyRef:
-                name: f8notification
-                key: keycloak.url
-          - name: F8_KEYCLOAK_REALM
-            valueFrom:
-              configMapKeyRef:
-                name: f8notification
-                key: keycloak.realm
           - name: F8_SERVICE_ACCOUNT_ID
             valueFrom:
               secretKeyRef:

--- a/openshift/f8notification.secrets.yaml
+++ b/openshift/f8notification.secrets.yaml
@@ -21,5 +21,3 @@ objects:
   data:
     wit.url: https://api.prod-preview.openshift.io
     auth.url: https://auth.prod-preview.openshift.io
-    keycloak.url: https://sso.prod-preview.openshift.io
-    keycloak.realm: fabric8-test

--- a/token/token.go
+++ b/token/token.go
@@ -22,7 +22,6 @@ type PublicKey struct {
 
 // Manager generate and find auth token information
 type Manager interface {
-	PublicKey(kid string) *rsa.PublicKey
 	PublicKeys() []*rsa.PublicKey
 }
 
@@ -55,11 +54,6 @@ func NewManager(config tokenManagerConfiguration) (Manager, error) {
 		}, "Public key added")
 	}
 	return tm, nil
-}
-
-// PublicKey returns the public key by the ID
-func (mgm *tokenManager) PublicKey(kid string) *rsa.PublicKey {
-	return mgm.publicKeysMap[kid]
 }
 
 // PublicKeys returns all the public keys

--- a/token/token.go
+++ b/token/token.go
@@ -1,0 +1,86 @@
+package token
+
+import (
+	"crypto/rsa"
+	"fmt"
+
+	authjwk "github.com/fabric8-services/fabric8-auth/token/jwk"
+	authservice "github.com/fabric8-services/fabric8-notification/auth/api"
+	"github.com/fabric8-services/fabric8-wit/log"
+	"github.com/pkg/errors"
+)
+
+// tokenManagerConfiguration represents configuration needed to construct a token manager
+type tokenManagerConfiguration interface {
+	GetAuthURL() string
+}
+
+// Permissions represents a "permissions" in the AuthorizationPayload
+type Permissions struct {
+	ResourceSetName *string `json:"resource_set_name"`
+	ResourceSetID   *string `json:"resource_set_id"`
+}
+
+type PublicKey struct {
+	KeyID string
+	Key   *rsa.PublicKey
+}
+
+// Manager generate and find auth token information
+type Manager interface {
+	PublicKey(kid string) *rsa.PublicKey
+	PublicKeys() []*rsa.PublicKey
+}
+
+type tokenManager struct {
+	publicKeysMap map[string]*rsa.PublicKey
+	publicKeys    []*PublicKey
+}
+
+// NewManager returns a new token Manager for handling tokens
+func NewManager(config tokenManagerConfiguration) (Manager, error) {
+	// Load public keys from Auth service and add them to the manager
+	tm := &tokenManager{
+		publicKeysMap: map[string]*rsa.PublicKey{},
+	}
+
+	keysEndpoint := fmt.Sprintf("%s%s", config.GetAuthURL(), authservice.KeysTokenPath())
+	remoteKeys, err := authjwk.FetchKeys(keysEndpoint)
+	if err != nil {
+		log.Error(nil, map[string]interface{}{
+			"err":      err,
+			"keys_url": keysEndpoint,
+		}, "unable to load public keys from remote service")
+		return nil, errors.New("unable to load public keys from remote service")
+	}
+	for _, remoteKey := range remoteKeys {
+		tm.publicKeysMap[remoteKey.KeyID] = remoteKey.Key
+		tm.publicKeys = append(tm.publicKeys, &PublicKey{KeyID: remoteKey.KeyID, Key: remoteKey.Key})
+		log.Info(nil, map[string]interface{}{
+			"kid": remoteKey.KeyID,
+		}, "Public key added")
+	}
+	return tm, nil
+}
+
+// NewManagerWithPublicKey returns a new token Manager for handling tokens with the only public key
+func NewManagerWithPublicKey(id string, key *rsa.PublicKey) Manager {
+	return &tokenManager{
+		publicKeysMap: map[string]*rsa.PublicKey{id: key},
+		publicKeys:    []*PublicKey{{KeyID: id, Key: key}},
+	}
+}
+
+// PublicKey returns the public key by the ID
+func (mgm *tokenManager) PublicKey(kid string) *rsa.PublicKey {
+	return mgm.publicKeysMap[kid]
+}
+
+// PublicKeys returns all the public keys
+func (mgm *tokenManager) PublicKeys() []*rsa.PublicKey {
+	keys := make([]*rsa.PublicKey, 0, len(mgm.publicKeysMap))
+	for _, key := range mgm.publicKeys {
+		keys = append(keys, key.Key)
+	}
+	return keys
+}

--- a/token/token.go
+++ b/token/token.go
@@ -15,12 +15,6 @@ type tokenManagerConfiguration interface {
 	GetAuthURL() string
 }
 
-// Permissions represents a "permissions" in the AuthorizationPayload
-type Permissions struct {
-	ResourceSetName *string `json:"resource_set_name"`
-	ResourceSetID   *string `json:"resource_set_id"`
-}
-
 type PublicKey struct {
 	KeyID string
 	Key   *rsa.PublicKey
@@ -61,14 +55,6 @@ func NewManager(config tokenManagerConfiguration) (Manager, error) {
 		}, "Public key added")
 	}
 	return tm, nil
-}
-
-// NewManagerWithPublicKey returns a new token Manager for handling tokens with the only public key
-func NewManagerWithPublicKey(id string, key *rsa.PublicKey) Manager {
-	return &tokenManager{
-		publicKeysMap: map[string]*rsa.PublicKey{id: key},
-		publicKeys:    []*PublicKey{{KeyID: id, Key: key}},
-	}
 }
 
 // PublicKey returns the public key by the ID

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,36 @@
+package token_test
+
+import (
+	//"context"
+	"os"
+	"testing"
+
+	"github.com/fabric8-services/fabric8-notification/configuration"
+	"github.com/fabric8-services/fabric8-notification/token"
+	//"github.com/fabric8-services/fabric8-notification/collector"
+	//"github.com/goadesign/goa/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	OpenShiftIOAuthAPI = "https://auth.openshift.io"
+)
+
+func TestManager(t *testing.T) {
+
+	old := os.Getenv("F8_AUTH_URL")
+	defer os.Setenv("F8_AUTH_URL", old)
+
+	os.Setenv("F8_AUTH_URL", "https://auth.openshift.io")
+	config, err := configuration.GetData()
+	assert.Nil(t, err)
+
+	manager, err := token.NewManager(config)
+	assert.Nil(t, err)
+
+	keys := manager.PublicKeys()
+	assert.NotEmpty(t, keys)
+	for _, k := range keys {
+		assert.NotNil(t, k.N)
+	}
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,15 +1,12 @@
 package token_test
 
 import (
-	//"context"
 	"os"
 	"testing"
 
 	"github.com/fabric8-services/fabric8-notification/configuration"
 	"github.com/fabric8-services/fabric8-notification/token"
-	//"github.com/fabric8-services/fabric8-notification/collector"
-	//"github.com/goadesign/goa/uuid"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -23,14 +20,15 @@ func TestManager(t *testing.T) {
 
 	os.Setenv("F8_AUTH_URL", "https://auth.openshift.io")
 	config, err := configuration.GetData()
-	assert.Nil(t, err)
+	require.NoError(t, err)
+	require.NotNil(t, config)
 
 	manager, err := token.NewManager(config)
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	keys := manager.PublicKeys()
-	assert.NotEmpty(t, keys)
+	require.NotEmpty(t, keys)
 	for _, k := range keys {
-		assert.NotNil(t, k.N)
+		require.NotNil(t, k.N)
 	}
 }

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -18,7 +18,7 @@ func TestManager(t *testing.T) {
 	old := os.Getenv("F8_AUTH_URL")
 	defer os.Setenv("F8_AUTH_URL", old)
 
-	os.Setenv("F8_AUTH_URL", "https://auth.openshift.io")
+	os.Setenv("F8_AUTH_URL", OpenShiftIOAuthAPI)
 	config, err := configuration.GetData()
 	require.NoError(t, err)
 	require.NotNil(t, config)


### PR DESCRIPTION
On startup, load keys from `http://auth/api/token/keys`

Startup logs should show something like

```
INFO[0000] Public keys loaded                            number_of_keys=3 pkg=github.com/fabric8-services/fabric8-notification/vendor/token/jwk url="http://localhost:8089/api/token/keys"
{"kid":"aUGv8mQA85jg4V1DU8Uk1W0uKsxn187KQONAGl6AMtc","level":"info","msg":"Public key added","pkg":"github.com/fabric8-services/fabric8-notification/token","time":"2018-07-04 14:25:42"}
{"kid":"9MLnViaRkhVj1GT9kpWUkwHIwUD-wZfUxR-3CpkE-Xs","level":"info","msg":"Public key added","pkg":"github.com/fabric8-services/fabric8-notification/token","time":"2018-07-04 14:25:42"}
{"kid":"bNq-BCOR3ev-E6buGSaPrU-0SXX8whhDlmZ6geenkTE","level":"info","msg":"Public key added","pkg":"github.com/fabric8-services/fabric8-notification/token","time":"2018-07-04 14:25:42"}
```