### PR TITLE
[WIP] Add parameter `revisionID` to payload of /notify

### DIFF
--- a/collector/cve.go
+++ b/collector/cve.go
@@ -10,7 +10,9 @@ import (
 )
 
 func NewCVEResolver(authClient *authapi.Client, witClient *api.Client) ReceiverResolver {
-	return func(ctx context.Context, url string) ([]Receiver, map[string]interface{}, error) {
+	return func(
+		ctx context.Context, url string, revisionID uuid.UUID,
+	) ([]Receiver, map[string]interface{}, error) {
 		codebases, err := wit.GetCodebases(ctx, witClient, url)
 		if err != nil {
 			return nil, nil, err

--- a/collector/cve_test.go
+++ b/collector/cve_test.go
@@ -13,6 +13,8 @@ import (
 	"github.com/fabric8-services/fabric8-notification/testsupport"
 	"github.com/fabric8-services/fabric8-notification/wit"
 	witApi "github.com/fabric8-services/fabric8-notification/wit/api"
+
+	"github.com/goadesign/goa/uuid"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -40,7 +42,7 @@ func TestCVEResolver(t *testing.T) {
 
 	cveResolver := collector.NewCVEResolver(authClient, witClient)
 	codebaseURL := "git@github.com:testrepo/testproject1.git"
-	recvs, _, err := cveResolver(context.Background(), codebaseURL)
+	recvs, _, err := cveResolver(context.Background(), codebaseURL, uuid.NewV4())
 
 	assert.Nil(t, err)
 	assert.NotNil(t, recvs)

--- a/collector/receiver.go
+++ b/collector/receiver.go
@@ -4,9 +4,13 @@ import (
 	"context"
 
 	"github.com/fabric8-services/fabric8-notification/types"
+
+	"github.com/goadesign/goa/uuid"
 )
 
-type ReceiverResolver func(context.Context, string) (users []Receiver, templateValues map[string]interface{}, err error)
+type ReceiverResolver func(
+	context.Context, string, uuid.UUID,
+) (users []Receiver, templateValues map[string]interface{}, err error)
 type ParamValidator func(context.Context, map[string]interface{}) error
 
 type Receiver struct {

--- a/collector/user.go
+++ b/collector/user.go
@@ -9,7 +9,9 @@ import (
 )
 
 func NewUserResolver(c *api.Client) ReceiverResolver {
-	return func(ctx context.Context, id string) ([]Receiver, map[string]interface{}, error) {
+	return func(
+		ctx context.Context, id string, revisionID uuid.UUID,
+	) ([]Receiver, map[string]interface{}, error) {
 		userID, err := uuid.FromString(id)
 		if err != nil {
 			return []Receiver{}, nil, fmt.Errorf("unable to lookup user based on id %v", id)

--- a/collector/workitem_test.go
+++ b/collector/workitem_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/fabric8-services/fabric8-notification/testsupport"
 	"github.com/fabric8-services/fabric8-notification/wit"
 	witApi "github.com/fabric8-services/fabric8-notification/wit/api"
+
 	"github.com/goadesign/goa/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -39,7 +40,11 @@ func TestWorkItem(t *testing.T) {
 	witClient, authClient := createClient(t)
 	wiID, _ := uuid.FromString("8bccc228-bba7-43ad-b077-15fbb9148f7f")
 
-	users, vars, err := collector.WorkItem(context.Background(), authClient, witClient, &testsupport.DummyCollaboratorCollector{}, wiID)
+	users, vars, err := collector.WorkItem(
+		context.Background(),
+		authClient, witClient,
+		&testsupport.DummyCollaboratorCollector{},
+		wiID, uuid.NewV4())
 	require.NoError(t, err)
 
 	assertWorkItemVars(t, vars)
@@ -57,7 +62,11 @@ func TestWorkItemUnverifiedEmails(t *testing.T) {
 	witClient, authClient := createClient(t)
 	wiID, _ := uuid.FromString("8bccc228-bba7-43ad-b077-15fbb9148f7f")
 
-	users, vars, err := collector.WorkItem(context.Background(), authClient, witClient, &testsupport.DummyCollaboratorCollector{}, wiID)
+	users, vars, err := collector.WorkItem(
+		context.Background(),
+		authClient, witClient,
+		&testsupport.DummyCollaboratorCollector{},
+		wiID, uuid.NewV4())
 	require.NoError(t, err)
 
 	assertWorkItemVars(t, vars)

--- a/collector/wrappers.go
+++ b/collector/wrappers.go
@@ -4,11 +4,15 @@ import (
 	"context"
 
 	"github.com/fabric8-services/fabric8-notification/configuration"
+
+	"github.com/goadesign/goa/uuid"
 )
 
 func ConfiguredVars(config *configuration.Data, resolver ReceiverResolver) ReceiverResolver {
-	return func(ctx context.Context, id string) ([]Receiver, map[string]interface{}, error) {
-		r, v, err := resolver(ctx, id)
+	return func(
+		ctx context.Context, id string, revisionID uuid.UUID,
+	) ([]Receiver, map[string]interface{}, error) {
+		r, v, err := resolver(ctx, id, revisionID)
 		if err != nil {
 			return r, v, err
 		}

--- a/collector/wrappers_test.go
+++ b/collector/wrappers_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/fabric8-services/fabric8-notification/configuration"
+
+	"github.com/goadesign/goa/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestConfigureVarsSetWebURL(t *testing.T) {
@@ -14,7 +15,7 @@ func TestConfigureVarsSetWebURL(t *testing.T) {
 	if err != nil {
 		assert.NoError(t, err)
 	}
-	u, v, err := ConfiguredVars(config, EmptyResolver)(context.Background(), "id")
+	u, v, err := ConfiguredVars(config, EmptyResolver)(context.Background(), "id", uuid.NewV4())
 	assert.NoError(t, err)
 	assert.Len(t, u, 0)
 	assert.Len(t, v, 1)
@@ -26,17 +27,17 @@ func TestConfigureVarsNilResolverVars(t *testing.T) {
 	if err != nil {
 		assert.NoError(t, err)
 	}
-	u, v, err := ConfiguredVars(config, NilVarResolver)(context.Background(), "id")
+	u, v, err := ConfiguredVars(config, NilVarResolver)(context.Background(), "id", uuid.NewV4())
 	assert.NoError(t, err)
 	assert.Len(t, u, 0)
 	assert.Len(t, v, 1)
 	assert.NotEmpty(t, v["webURL"])
 }
 
-func EmptyResolver(context.Context, string) (users []Receiver, templateValues map[string]interface{}, err error) {
+func EmptyResolver(context.Context, string, uuid.UUID) (users []Receiver, templateValues map[string]interface{}, err error) {
 	return []Receiver{}, map[string]interface{}{}, nil
 }
 
-func NilVarResolver(context.Context, string) (users []Receiver, templateValues map[string]interface{}, err error) {
+func NilVarResolver(context.Context, string, uuid.UUID) (users []Receiver, templateValues map[string]interface{}, err error) {
 	return []Receiver{}, nil, nil
 }

--- a/design/notify.go
+++ b/design/notify.go
@@ -29,6 +29,9 @@ var notificationAttributes = a.Type("NotificationAttributes", func() {
 	a.Attribute("custom", a.HashOf(d.String, d.Any), "custom information to be passed as a json", func() {
 		a.Example(map[string]interface{}{"verification_url": "https://auth.openshift.io/api/user/verifyEmail?code=bb9148f7"})
 	})
+	a.Attribute("revisionID", d.UUID, "ID of revision that triggered this notification", func() {
+		a.Example("1646e178-b90e-48b4-85e4-204d1c4c416f")
+	})
 	a.Required("type", "id")
 })
 

--- a/email/notifier.go
+++ b/email/notifier.go
@@ -5,7 +5,9 @@ import (
 
 	"github.com/fabric8-services/fabric8-notification/collector"
 	"github.com/fabric8-services/fabric8-notification/template"
+
 	"github.com/fabric8-services/fabric8-wit/log"
+	"github.com/goadesign/goa/uuid"
 )
 
 type contextualNotification struct {
@@ -16,6 +18,7 @@ type contextualNotification struct {
 type Notification struct {
 	Type             string
 	ID               string
+	RevisionID       uuid.UUID
 	CustomAttributes map[string]interface{}
 	Resolver         collector.ReceiverResolver
 	Template         template.Template
@@ -71,7 +74,7 @@ func (a *AsyncWorkerNotifier) work() {
 func (a *AsyncWorkerNotifier) do(cn contextualNotification) {
 	ctx, notification := cn.context, cn.notification
 
-	receivers, vars, err := notification.Resolver(ctx, notification.ID)
+	receivers, vars, err := notification.Resolver(ctx, notification.ID, notification.RevisionID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
 			"type": notification.ID,

--- a/email/notifier_test.go
+++ b/email/notifier_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/fabric8-services/fabric8-notification/collector"
 	"github.com/fabric8-services/fabric8-notification/template"
 	"github.com/fabric8-services/fabric8-notification/types"
+
+	"github.com/goadesign/goa/uuid"
 )
 
 type TestSender struct {
@@ -19,7 +21,7 @@ func (t *TestSender) Send(ctx context.Context, subject string, body string, head
 
 func TestAsyncWorkerNotifier(t *testing.T) {
 
-	resolver := func(ctx context.Context, id string) ([]collector.Receiver, map[string]interface{}, error) {
+	resolver := func(ctx context.Context, id string, revisionID uuid.UUID) ([]collector.Receiver, map[string]interface{}, error) {
 		return []collector.Receiver{}, nil, nil
 	}
 

--- a/preview/main.go
+++ b/preview/main.go
@@ -33,37 +33,44 @@ func main() {
 
 	type data struct {
 		id           string
+		revisionID   string
 		templateName string
 	}
 
 	var testdata []data
-	testdata = append(testdata, data{"de4871ce-0bfd-4b4b-aee2-e02427f4e38b", string(types.WorkitemCreate)})
-	testdata = append(testdata, data{"43024450-fe8c-4082-8828-88512cebfdb0", string(types.WorkitemCreate)})
-	testdata = append(testdata, data{"3a331aa3-6423-4fd7-85e4-95d7932b168c", string(types.WorkitemCreate)})
-	testdata = append(testdata, data{"d85e19a1-f4aa-486e-a8fe-3211cac9b68f", string(types.WorkitemCreate)})
-	testdata = append(testdata, data{"43024450-fe8c-4082-8828-88512cebfdb0", string(types.WorkitemUpdate)})
+	testdata = append(testdata, data{"de4871ce-0bfd-4b4b-aee2-e02427f4e38b", "", string(types.WorkitemCreate)})
+	testdata = append(testdata, data{"43024450-fe8c-4082-8828-88512cebfdb0", "", string(types.WorkitemCreate)})
+	testdata = append(testdata, data{"3a331aa3-6423-4fd7-85e4-95d7932b168c", "", string(types.WorkitemCreate)})
+	testdata = append(testdata, data{"d85e19a1-f4aa-486e-a8fe-3211cac9b68f", "", string(types.WorkitemCreate)})
+	testdata = append(testdata, data{"43024450-fe8c-4082-8828-88512cebfdb0", "f8b9e70c-d3cf-4496-b2d1-7cb64f74c886", string(types.WorkitemUpdate)})
 
-	testdata = append(testdata, data{"d28f8344-4956-497a-b43b-7f217087a931", string(types.CommentCreate)})
-	testdata = append(testdata, data{"51d968b1-b9e5-4ec1-884a-ff256902c753", string(types.CommentCreate)})
-	testdata = append(testdata, data{"51d968b1-b9e5-4ec1-884a-ff256902c753", string(types.CommentUpdate)})
-	testdata = append(testdata, data{"3383826c-51e4-401b-9ccd-b898f7e2397d", string(types.UserEmailUpdate)})
-	testdata = append(testdata, data{"81d1c3bf-fcf2-4c4e-9d12-f9e5c15fb9ab", string(types.InvitationTeamNoorg)})
-	testdata = append(testdata, data{"297f2037-72e9-42b3-a5fc-76d843877163", string(types.InvitationSpaceNoorg)})
+	testdata = append(testdata, data{"d28f8344-4956-497a-b43b-7f217087a931", "", string(types.CommentCreate)})
+	testdata = append(testdata, data{"51d968b1-b9e5-4ec1-884a-ff256902c753", "", string(types.CommentCreate)})
+	testdata = append(testdata, data{"51d968b1-b9e5-4ec1-884a-ff256902c753", "", string(types.CommentUpdate)})
+	testdata = append(testdata, data{"3383826c-51e4-401b-9ccd-b898f7e2397d", "", string(types.UserEmailUpdate)})
+	testdata = append(testdata, data{"81d1c3bf-fcf2-4c4e-9d12-f9e5c15fb9ab", "", string(types.InvitationTeamNoorg)})
+	testdata = append(testdata, data{"297f2037-72e9-42b3-a5fc-76d843877163", "", string(types.InvitationSpaceNoorg)})
 
-	testdata = append(testdata, data{"0a9c6814-462e-411c-8560-d74297bf1ceb", string(types.AnalyticsNotifyCVE)})
+	testdata = append(testdata, data{"0a9c6814-462e-411c-8560-d74297bf1ceb", "", string(types.AnalyticsNotifyCVE)})
 
 	fmt.Println("Generating test templates..")
 	fmt.Println("")
 
 	for _, d := range testdata {
-		err = generate(authClient, c, d.id, d.templateName)
+		revisionID, _ := uuid.FromString(d.revisionID)
+		err = generate(authClient, c, d.id, d.templateName, revisionID)
 		if err != nil {
 			fmt.Printf(err.Error())
 		}
 	}
 }
 
-func generate(authClient *authapi.Client, c *api.Client, id, tmplName string) error {
+func generate(
+	authClient *authapi.Client,
+	c *api.Client,
+	id, tmplName string,
+	revisionID uuid.UUID) error {
+
 	reg := template.AssetRegistry{}
 
 	temp, exist := reg.Get(tmplName)
@@ -77,7 +84,7 @@ func generate(authClient *authapi.Client, c *api.Client, id, tmplName string) er
 	var err error
 
 	if strings.HasPrefix(tmplName, "workitem") {
-		_, vars, err = collector.WorkItem(context.Background(), authClient, c, nil, wiID)
+		_, vars, err = collector.WorkItem(context.Background(), authClient, c, nil, wiID, revisionID)
 	} else if strings.HasPrefix(tmplName, "comment") {
 		_, vars, err = collector.Comment(context.Background(), authClient, c, nil, wiID)
 	} else if strings.HasPrefix(tmplName, "user") {

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/fabric8-services/fabric8-notification/types"
 	"github.com/fabric8-services/fabric8-notification/wit"
 	witApi "github.com/fabric8-services/fabric8-notification/wit/api"
+
 	"github.com/goadesign/goa/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -65,7 +66,11 @@ func TestRenderWorkitemCreate(t *testing.T) {
 	witClient, authClient := createClient(t)
 	wiID, _ := uuid.FromString("8bccc228-bba7-43ad-b077-15fbb9148f7f")
 
-	_, vars, err := collector.WorkItem(context.Background(), authClient, witClient, &testsupport.DummyCollaboratorCollector{}, wiID)
+	_, vars, err := collector.WorkItem(
+		context.Background(),
+		authClient, witClient,
+		&testsupport.DummyCollaboratorCollector{},
+		wiID, uuid.NewV4())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -99,7 +104,11 @@ func TestRenderWorkitemCreateMissingDescription(t *testing.T) {
 	witClient, authClient := createClient(t)
 	wiID, _ := uuid.FromString("8bccc228-bba7-43ad-b077-15fbb9148f7f")
 
-	_, vars, err := collector.WorkItem(context.Background(), authClient, witClient, &testsupport.DummyCollaboratorCollector{}, wiID)
+	_, vars, err := collector.WorkItem(
+		context.Background(),
+		authClient, witClient,
+		&testsupport.DummyCollaboratorCollector{},
+		wiID, uuid.NewV4())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -136,7 +145,11 @@ func TestRenderWorkitemUpdate(t *testing.T) {
 	witClient, authClient := createClient(t)
 	wiID, _ := uuid.FromString("8bccc228-bba7-43ad-b077-15fbb9148f7f")
 
-	_, vars, err := collector.WorkItem(context.Background(), authClient, witClient, &testsupport.DummyCollaboratorCollector{}, wiID)
+	_, vars, err := collector.WorkItem(
+		context.Background(),
+		authClient, witClient,
+		&testsupport.DummyCollaboratorCollector{},
+		wiID, uuid.NewV4())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/wit/client.go
+++ b/wit/client.go
@@ -161,3 +161,23 @@ func GetCodebases(ctx context.Context, client *api.Client, url string) (*api.Cod
 	}
 	return client.DecodeCodebaseList(resp)
 }
+
+// GetWorkItemEvents make call on wit at endpoint /api/workitems/:workitem-id/events
+func GetWorkItemEvents(
+	ctx context.Context, client *api.Client, wiID uuid.UUID,
+) (*api.EventList, error) {
+	resp, err := client.ListWorkItemEvents(
+		goasupport.ForwardContextRequestID(ctx),
+		api.ListWorkItemEventsPath(wiID), nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("non %v status code for %v, returned %v",
+			http.StatusOK, "GET workitem events", resp.StatusCode)
+	}
+
+	return client.DecodeEventList(resp)
+}


### PR DESCRIPTION
Right now the only information sent by wit to notification service is
workitem-id. Based on that generating effective notification is hard
specially when there are updates.

So this commit adds a parameter to the endpoint /notify called
`revisionID` which wit can use to send the UUID of the
event/notification. With this information notification can be generated
correctly.