### PR TITLE
Adds support for version notifications

### DIFF
--- a/main.go
+++ b/main.go
@@ -112,7 +112,7 @@ func main() {
 	registry.Register(types.InvitationTeamNoorg, collector.ConfiguredVars(config, collector.NewUserResolver(authClient)), nil)
 	registry.Register(types.InvitationSpaceNoorg, collector.ConfiguredVars(config, collector.NewUserResolver(authClient)), nil)
 	registry.Register(types.AnalyticsNotifyCVE, collector.ConfiguredVars(config, collector.NewCVEResolver(authClient, witClient)), nil)
-
+	registry.Register(types.AnalyticsNotifyVersion, collector.ConfiguredVars(config, collector.NewCVEResolver(authClient, witClient)), nil)
 	templateRegistry := &template.AssetRegistry{}
 	service := goa.New("notification")
 

--- a/preview/main.go
+++ b/preview/main.go
@@ -51,6 +51,7 @@ func main() {
 	testdata = append(testdata, data{"297f2037-72e9-42b3-a5fc-76d843877163", string(types.InvitationSpaceNoorg)})
 
 	testdata = append(testdata, data{"0a9c6814-462e-411c-8560-d74297bf1ceb", string(types.AnalyticsNotifyCVE)})
+	testdata = append(testdata, data{"7dd737ed-c0fa-4f2f-9a3a-ed43778bb7fe", string(types.AnalyticsNotifyVersion)})
 
 	fmt.Println("Generating test templates..")
 	fmt.Println("")
@@ -96,13 +97,19 @@ func generate(authClient *authapi.Client, c *api.Client, id, tmplName string) er
 			"acceptURL": "http://openshift.io/invitations/accept/12345-ABCDE-FFFFF-99999-88888",
 		}
 
-	} else if strings.HasPrefix(tmplName, "analytics") {
+	} else if strings.HasPrefix(tmplName, "analytics.notify.cve") {
 		vars = make(map[string]interface{})
 		payload, err := testsupport.GetFileContent("preview/test-files/cve.payload.json")
 		if err == nil {
 			vars["custom"] = testsupport.GetCustomElement(payload)
 		}
-	} else {
+	} else if strings.HasPrefix(tmplName, "analytics.notify.version") {
+		vars = make(map[string]interface{})
+		payload, err := testsupport.GetFileContent("preview/test-files/ver.payload.json")
+		if err == nil {
+			vars["custom"] = testsupport.GetCustomElement(payload)
+		}
+	}else {
 		return fmt.Errorf("Unkown resolver for template %v", tmplName)
 	}
 

--- a/preview/main.go
+++ b/preview/main.go
@@ -109,7 +109,7 @@ func generate(authClient *authapi.Client, c *api.Client, id, tmplName string) er
 		if err == nil {
 			vars["custom"] = testsupport.GetCustomElement(payload)
 		}
-	}else {
+	} else {
 		return fmt.Errorf("Unkown resolver for template %v", tmplName)
 	}
 

--- a/preview/main.go
+++ b/preview/main.go
@@ -105,7 +105,7 @@ func generate(authClient *authapi.Client, c *api.Client, id, tmplName string) er
 		}
 	} else if strings.HasPrefix(tmplName, "analytics.notify.version") {
 		vars = make(map[string]interface{})
-		payload, err := testsupport.GetFileContent("preview/test-files/ver.payload.json")
+		payload, err := testsupport.GetFileContent("preview/test-files/version.payload.json")
 		if err == nil {
 			vars["custom"] = testsupport.GetCustomElement(payload)
 		}

--- a/preview/test-files/ver.payload.json
+++ b/preview/test-files/ver.payload.json
@@ -1,0 +1,21 @@
+{  
+   "type":"notifications",
+   "id":"634444a1-b1dc-4be3-bcf3-64c596a06b2d",
+   "data":{  
+      "attributes":{  
+         "custom":{  
+            "repo_url":"git@github.com:testrepo/testproject.git",
+            "version_updates":[  
+               {  
+                  "version":"3.4.1",
+                  "latest_version":"3.4.2",
+                  "name":"io.vertx:vertx-web",
+                  "ecosystem":"maven"
+               }
+            ]
+         },
+         "type":"analytics.notify.version",
+         "id":"git@github.com:testrepo/testproject.git"
+      }
+   }
+}

--- a/preview/test-files/ver.payload.json
+++ b/preview/test-files/ver.payload.json
@@ -1,6 +1,4 @@
 {  
-   "type":"notifications",
-   "id":"634444a1-b1dc-4be3-bcf3-64c596a06b2d",
    "data":{  
       "attributes":{  
          "custom":{  
@@ -16,6 +14,8 @@
          },
          "type":"analytics.notify.version",
          "id":"git@github.com:testrepo/testproject.git"
-      }
+      },
+      "type":"notifications",
+      "id":"634444a1-b1dc-4be3-bcf3-64c596a06b2d"
    }
 }

--- a/preview/test-files/version.payload.json
+++ b/preview/test-files/version.payload.json
@@ -1,0 +1,21 @@
+{  
+   "data":{  
+      "attributes":{  
+         "custom":{  
+            "repo_url":"git@github.com:testrepo/testproject.git",
+            "scanned_at": "2018-06-18T12:25:24",
+            "version_updates":[  
+               {  
+                  "version":"3.4.1",
+                  "latest_version":"3.4.2",
+                  "name":"io.vertx:vertx-web"
+               }
+            ]
+         },
+         "type":"analytics.notify.version",
+         "id":"git@github.com:testrepo/testproject.git"
+      },
+      "type":"notifications",
+      "id":"634444a1-b1dc-4be3-bcf3-64c596a06b2d"
+   }
+}

--- a/preview/test-files/version.payload.json
+++ b/preview/test-files/version.payload.json
@@ -8,7 +8,8 @@
                {  
                   "version":"3.4.1",
                   "latest_version":"3.4.2",
-                  "name":"io.vertx:vertx-web"
+                  "name":"io.vertx:vertx-web",
+                  "ecosystem":"maven"
                }
             ]
          },

--- a/template/analytics.notify.version/body.html
+++ b/template/analytics.notify.version/body.html
@@ -87,7 +87,7 @@
       </div>
       <div style="margin-top: 15px;color:#363636;font-weight: 600;">
           <span>Direct dependencies with latest version:</span>
-          <span> 04</span>
+          <span> {{ len .custom.version_updates }}</span>
       </div>
       <div style="margin-top: 25px;">
         <span style="color:#72767B;font-weight: 600;">Details of direct dependencies</span>
@@ -105,7 +105,6 @@
           <td>{{$dependency.name}}</td>
           <td style="text-align: center;">{{$dependency.version}}</td>
           <td style="text-align: center;">{{$dependency.latest_version}}</td>
-          <td></td>
         </tr>
         {{ end }}
       </table>

--- a/template/analytics.notify.version/body.html
+++ b/template/analytics.notify.version/body.html
@@ -77,9 +77,9 @@
       <div style="margin-top: 15px;color:#72767B;">
         <span>
           <span style="font-weight: 600;color:#363636;">Scan report</span> for GitHub repository
-          <a href="https://github.com/fabric8-ui/fabric8-ui" style="color: #0088ce; text-decoration: none;">https://github.com/fabric8-ui/fabric8-ui</a>
+          <a href={{.custom.repo_url}} style="color: #0088ce; text-decoration: none;">{{.custom.repo_url}}</a>
           <span style="border-left: 1px solid #72767B;padding-left: 5px;"> Scan done on:</span>
-          <span> Tue, 20 March 2018 18:17:50 GMT</span>
+          <span>{{.custom.scanned_at}}</span>
         </span>
       </div>
       <div style="margin-top: 25px;">
@@ -87,7 +87,7 @@
       </div>
       <div style="margin-top: 15px;color:#363636;font-weight: 600;">
           <span>Direct dependencies with latest version:</span>
-          <span> {{ len .custom.version_updates }}</span>
+          <span>{{len .custom.version_updates}}</span>
       </div>
       <div style="margin-top: 25px;">
         <span style="color:#72767B;font-weight: 600;">Details of direct dependencies</span>

--- a/template/analytics.notify.version/body.html
+++ b/template/analytics.notify.version/body.html
@@ -99,18 +99,15 @@
           <th style="text-align: center;">Current Version</th>
           <th style="text-align: center;">Latest Version</th>
         </tr>
+        {{ range $depsInd, $dependency := .custom.version_updates }}
         <tr>
-          <td>#01</td>
-          <td>com.logback.core</td>
-          <td style="text-align: center;">2.0</td>
-          <td style="text-align: center;">2.1</td>
+          <td>#{{inc $depsInd}}</td>
+          <td>{{$dependency.name}}</td>
+          <td style="text-align: center;">{{$dependency.version}}</td>
+          <td style="text-align: center;">{{$dependency.latest_version}}</td>
+          <td></td>
         </tr>
-        <tr>
-          <td>#02</td>
-          <td>com.logback.web</td>
-          <td style="text-align: center;">1.5</td>
-          <td style="text-align: center;">1.8</td>
-        </tr>
+        {{ end }}
       </table>
     </div>
     <div style="

--- a/template/analytics.notify.version/body.html
+++ b/template/analytics.notify.version/body.html
@@ -98,6 +98,7 @@
           <th>Direct dependency</th> 
           <th style="text-align: center;">Current Version</th>
           <th style="text-align: center;">Latest Version</th>
+          <th style="text-align: center;">Ecosystem</th>
         </tr>
         {{ range $depsInd, $dependency := .custom.version_updates }}
         <tr>
@@ -105,6 +106,7 @@
           <td>{{$dependency.name}}</td>
           <td style="text-align: center;">{{$dependency.version}}</td>
           <td style="text-align: center;">{{$dependency.latest_version}}</td>
+          <td style="text-align: center;">{{$dependency.ecosystem}}</td>
         </tr>
         {{ end }}
       </table>

--- a/template/analytics.notify.version/body.html
+++ b/template/analytics.notify.version/body.html
@@ -120,15 +120,7 @@
         <span style="font-weight: 600;">
           To unsubscribe:
         </span> 
-        Turn OFF `Security Alert Notification` in the
-        <span>
-          <a href="http://codebase-url"
-              style="
-                color: #0088ce;
-                text-decoration: none;">
-                Codebase page</a>
-        </span>
-        in your space.
+        Turn OFF `Security Alert Notification` in the Codebase page in your space.
       </span>
     </div>
   </div>

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -341,6 +341,46 @@ func checkCVEBody(t *testing.T, body string, custom map[string]interface{}) {
 	}
 }
 
+func TestRenderVersion(t *testing.T) {
+	files := []string{"version"}
+	reg := template.AssetRegistry{}
+	template, exist := reg.Get(string(types.AnalyticsNotifyVersion))
+	assert.True(t, exist)
+
+	for _, file := range files {
+		t.Run(file, func(t *testing.T) {
+			vars := make(map[string]interface{})
+			payload, err := testsupport.GetFileContent(fmt.Sprintf("test-files/%s.json", file))
+			require.NoError(t, err)
+
+			vars["custom"] = testsupport.GetCustomElement(payload)
+
+			sub, body, _, err := template.Render(addGlobalVars(vars))
+			require.NoError(t, err)
+
+			custom := toMap(vars["custom"])
+
+			assert.True(t, strings.Contains(sub, toString(custom["repo_url"])))
+			checkVersionBody(t, body, custom)
+		})
+	}
+}
+
+func checkVersionBody(t *testing.T, body string, custom map[string]interface{}) {
+	t.Helper()
+	assert.True(t, strings.Contains(body, toString(custom["repo_url"])))
+	assert.True(t, strings.Contains(body, toString(custom["scanned_at"])))
+
+	depArr := toArrMap(custom["version_updates"])
+	assert.NotNil(t, depArr)
+
+	for _, dep := range depArr {
+		assert.True(t, strings.Contains(body, toString(dep["name"])))
+		assert.True(t, strings.Contains(body, toString(dep["latest_version"])))
+		assert.True(t, strings.Contains(body, toString(dep["version"])))
+	}
+}
+
 func toString(val interface{}) string {
 	if str, ok := val.(string); ok {
 		return str

--- a/template/template_test.go
+++ b/template/template_test.go
@@ -321,26 +321,6 @@ func TestRenderCVE(t *testing.T) {
 	}
 }
 
-func checkCVEBody(t *testing.T, body string, custom map[string]interface{}) {
-	t.Helper()
-	assert.True(t, strings.Contains(body, toString(custom["repo_url"])))
-	assert.True(t, strings.Contains(body, toString(custom["scanned_at"])))
-
-	depArr := toArrMap(custom["vulnerable_deps"])
-	assert.NotNil(t, depArr)
-
-	for _, dep := range depArr {
-		assert.True(t, strings.Contains(body, toString(dep["name"])))
-		cveArr := toArrMap(dep["cves"])
-		assert.NotNil(t, depArr)
-		for _, cve := range cveArr {
-			assert.True(t, strings.Contains(body, toString(cve["CVE"])))
-			cvss := fmt.Sprintf("[%s/10]", toString(cve["CVSS"]))
-			assert.True(t, strings.Contains(body, cvss))
-		}
-	}
-}
-
 func TestRenderVersion(t *testing.T) {
 	files := []string{"version"}
 	reg := template.AssetRegistry{}
@@ -366,6 +346,26 @@ func TestRenderVersion(t *testing.T) {
 	}
 }
 
+func checkCVEBody(t *testing.T, body string, custom map[string]interface{}) {
+	t.Helper()
+	assert.True(t, strings.Contains(body, toString(custom["repo_url"])))
+	assert.True(t, strings.Contains(body, toString(custom["scanned_at"])))
+
+	depArr := toArrMap(custom["vulnerable_deps"])
+	assert.NotNil(t, depArr)
+
+	for _, dep := range depArr {
+		assert.True(t, strings.Contains(body, toString(dep["name"])))
+		cveArr := toArrMap(dep["cves"])
+		assert.NotNil(t, depArr)
+		for _, cve := range cveArr {
+			assert.True(t, strings.Contains(body, toString(cve["CVE"])))
+			cvss := fmt.Sprintf("[%s/10]", toString(cve["CVSS"]))
+			assert.True(t, strings.Contains(body, cvss))
+		}
+	}
+}
+
 func checkVersionBody(t *testing.T, body string, custom map[string]interface{}) {
 	t.Helper()
 	assert.True(t, strings.Contains(body, toString(custom["repo_url"])))
@@ -376,8 +376,9 @@ func checkVersionBody(t *testing.T, body string, custom map[string]interface{}) 
 
 	for _, dep := range depArr {
 		assert.True(t, strings.Contains(body, toString(dep["name"])))
-		assert.True(t, strings.Contains(body, toString(dep["latest_version"])))
 		assert.True(t, strings.Contains(body, toString(dep["version"])))
+		assert.True(t, strings.Contains(body, toString(dep["latest_version"])))
+		assert.True(t, strings.Contains(body, toString(dep["ecosystem"])))
 	}
 }
 

--- a/template/test-files/version.json
+++ b/template/test-files/version.json
@@ -3,12 +3,17 @@
       "attributes":{  
          "custom":{  
             "repo_url":"git@github.com:testrepo/testproject.git",
+            "scanned_at": "2018-06-18T12:25:24",
             "version_updates":[  
                {  
                   "version":"3.4.1",
                   "latest_version":"3.4.2",
-                  "name":"io.vertx:vertx-web",
-                  "ecosystem":"maven"
+                  "name":"io.vertx:vertx-web"
+               },
+               {  
+                  "version":"3.5.0",
+                  "latest_version":"3.5.1",
+                  "name":"io.vertx:vertx-util"
                }
             ]
          },

--- a/template/test-files/version.json
+++ b/template/test-files/version.json
@@ -8,12 +8,14 @@
                {  
                   "version":"3.4.1",
                   "latest_version":"3.4.2",
-                  "name":"io.vertx:vertx-web"
+                  "name":"io.vertx:vertx-web",
+                  "ecosystem":"maven"
                },
                {  
                   "version":"3.5.0",
                   "latest_version":"3.5.1",
-                  "name":"io.vertx:vertx-util"
+                  "name":"io.vertx:vertx-util",
+                  "ecosystem":"maven"
                }
             ]
          },

--- a/types/type.go
+++ b/types/type.go
@@ -3,20 +3,20 @@ package types
 type NotificationType string
 
 const (
-	WorkitemCreate       	 NotificationType = "workitem.create"
-	WorkitemUpdate       	 NotificationType = "workitem.update"
-	CommentCreate        	 NotificationType = "comment.create"
-	CommentUpdate        	 NotificationType = "comment.update"
-	UserEmailUpdate      	 NotificationType = "user.email.update"
-	InvitationTeamNoorg  	 NotificationType = "invitation.team.noorg"
-	InvitationSpaceNoorg 	 NotificationType = "invitation.space.noorg"
-	AnalyticsNotifyCVE   	 NotificationType = "analytics.notify.cve"
-	AnalyticsNotifyVersion   NotificationType = "analytics.notify.version"
+	WorkitemCreate         NotificationType = "workitem.create"
+	WorkitemUpdate         NotificationType = "workitem.update"
+	CommentCreate          NotificationType = "comment.create"
+	CommentUpdate          NotificationType = "comment.update"
+	UserEmailUpdate        NotificationType = "user.email.update"
+	InvitationTeamNoorg    NotificationType = "invitation.team.noorg"
+	InvitationSpaceNoorg   NotificationType = "invitation.space.noorg"
+	AnalyticsNotifyCVE     NotificationType = "analytics.notify.cve"
+	AnalyticsNotifyVersion NotificationType = "analytics.notify.version"
 )
 
 var notifiers = map[NotificationType][]string{
-	AnalyticsNotifyCVE: {"fabric8-gemini-server"},
-	UserEmailUpdate:    {"fabric8-auth"},
+	AnalyticsNotifyCVE:     {"fabric8-gemini-server"},
+	UserEmailUpdate:        {"fabric8-auth"},
 	AnalyticsNotifyVersion: {"fabric8-gemini-server"},
 }
 

--- a/types/type.go
+++ b/types/type.go
@@ -3,14 +3,15 @@ package types
 type NotificationType string
 
 const (
-	WorkitemCreate       NotificationType = "workitem.create"
-	WorkitemUpdate       NotificationType = "workitem.update"
-	CommentCreate        NotificationType = "comment.create"
-	CommentUpdate        NotificationType = "comment.update"
-	UserEmailUpdate      NotificationType = "user.email.update"
-	InvitationTeamNoorg  NotificationType = "invitation.team.noorg"
-	InvitationSpaceNoorg NotificationType = "invitation.space.noorg"
-	AnalyticsNotifyCVE   NotificationType = "analytics.notify.cve"
+	WorkitemCreate       	 NotificationType = "workitem.create"
+	WorkitemUpdate       	 NotificationType = "workitem.update"
+	CommentCreate        	 NotificationType = "comment.create"
+	CommentUpdate        	 NotificationType = "comment.update"
+	UserEmailUpdate      	 NotificationType = "user.email.update"
+	InvitationTeamNoorg  	 NotificationType = "invitation.team.noorg"
+	InvitationSpaceNoorg 	 NotificationType = "invitation.space.noorg"
+	AnalyticsNotifyCVE   	 NotificationType = "analytics.notify.cve"
+	AnalyticsNotifyVersion   NotificationType = "analytics.notify.version"
 )
 
 var notifiers = map[NotificationType][]string{

--- a/types/type.go
+++ b/types/type.go
@@ -17,6 +17,7 @@ const (
 var notifiers = map[NotificationType][]string{
 	AnalyticsNotifyCVE: {"fabric8-gemini-server"},
 	UserEmailUpdate:    {"fabric8-auth"},
+	AnalyticsNotifyVersion: {"fabric8-analytic-notification-scheduler"},
 }
 
 func (nType NotificationType) Notifiers() []string {

--- a/types/type.go
+++ b/types/type.go
@@ -17,7 +17,7 @@ const (
 var notifiers = map[NotificationType][]string{
 	AnalyticsNotifyCVE: {"fabric8-gemini-server"},
 	UserEmailUpdate:    {"fabric8-auth"},
-	AnalyticsNotifyVersion: {"fabric8-analytic-notification-scheduler"},
+	AnalyticsNotifyVersion: {"fabric8-gemini-server"},
 }
 
 func (nType NotificationType) Notifiers() []string {


### PR DESCRIPTION
This PR adds support for version notifications. A new type by the name `AnalyticsNotifyVersion` is registered which points to cve.go and gathers users and their corresponding emails . This information is used to render an an html template and hence an email is sent to the users.
Signed-off-by: Geetika Batra <gbatra@redhat.com>