### PR TITLE
fix(CRT-215): rephrase deactivation email to get rid of openShift.io

### DIFF
--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -2,6 +2,11 @@ FROM centos:7
 MAINTAINER "Aslak Knutsen <aslak@redhat.com>"
 ENV LANG=en_US.utf8
 
+############################################################
+# workaround for https://bugs.centos.org/view.php?id=16337 #
+RUN echo -e "exclude=mirror.ci.centos.org" >> /etc/yum/pluginconf.d/fastestmirror.conf
+############################################################
+
 # Some packages might seem weird but they are required by the RVM installer.
 RUN yum install epel-release --enablerepo=extras -y \
     && yum --enablerepo=centosplus --enablerepo=epel-testing install -y \

--- a/template/user.deactivation/body.html
+++ b/template/user.deactivation/body.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>
-Notice: Your OpenShift.io free account is inactive
+Notice: Your Red Hat CodeReady Toolchain free account is inactive
   </title>
   <style>
     a:hover {
@@ -39,19 +39,10 @@ Notice: Your OpenShift.io free account is inactive
         background-color: #fff;
         box-shadow: 0 2px 4px #d7d7d7;"
 >
-  <div
-          style="
-            font-weight: bold;"
-  >Che.OpenShift.io and OpenShift.io</div>
-  <div
-          style="
-            margin: 15px auto 0;
-            border: 1px solid #d7d7d7;"
-  ></div>
 
   <p>
-    You are receiving this email because you have a free online <a href="https://openshift.io">OpenShift.io</a> account
-    associated with {{ .custom.userEmail }}
+    You are receiving this email because you have a free online <a href="https://che.openshift.io">Red Hat CodeReady Toolchain</a>
+    account associated with {{ .custom.userEmail }}.
   </p>
 
   <p>
@@ -59,26 +50,21 @@ Notice: Your OpenShift.io free account is inactive
   </p>
 
   <p>
-    To keep your account active, please log in by <strong>{{ .custom.expiryDate }}</strong> to ensure
-    uninterrupted use of <a href="https://openshift.io">OpenShift.io</a>
+    To keep your account active, please log in to <a href="https://che.openshift.io">che.openshift.io</a>,
+    by <strong>{{ .custom.expiryDate }}</strong> to ensure uninterrupted use.
   </p>
 
   <p>
-    <a href="https://openshift.io">OpenShift.io</a> |
-    <a href="https://che.openshift.io">Che.OpenShift.io</a>
+    Inaction will result in the deletion of your account and data.
   </p>
 
   <p>
-    Inaction will result in the removal of your account, data, and access to <a href="https://openshift.io">OpenShift.io</a>
-  </p>
-
-  <p>
-    Once closed, accounts cannot be reactivated. To create a new account, please visit <a href="https://openshift.io">OpenShift.io</a>
+    Deleted accounts cannot be reactivated. To create a new account, please visit <a href="https://che.openshift.io">che.openshift.io</a>.
   </p>
 
   <p>
     Thanks,<br />
-    The OpenShift.io Team
+    The Red Hat CodeReady Toolchain team
   </p>
 </div>
 </body>

--- a/template/user.deactivation/subject.txt
+++ b/template/user.deactivation/subject.txt
@@ -1,1 +1,1 @@
-Notice: Your OpenShift.io free account is inactive
+Notice: Your Red Hat CodeReady Toolchain free account is inactive


### PR DESCRIPTION
The deactivation email is changed so it doesn't have so much OpenShift.io all over it.
The new email will look like:

---
<html lang="en">
  <body
          style="
          padding: 10px;
          padding: 0;
          background-color: #f9f9f9;
          font-family: 'Open Sans', sans-serif;
          font-size: 15px;
          font-weight: lighter;
          line-height: 1.2;"
  >
  <div
          style="
          min-height: 300px;
          max-width: 750px;
          margin: 0 auto;
          padding: 20px;
          border: 1px solid #d7d7d7;
          border-radius: 4px;
          background-color: #fff;
          box-shadow: 0 2px 4px #d7d7d7;"
  >
    <p>
      You are receiving this email because you have a free online <a href="https://che.openshift.io">Red Hat CodeReady Toolchain</a>
      account associated with john@acme.com.
    </p>
    <p>
      Action is required to keep your account active.
    </p>
    <p>
      To keep your account active, please log in to <a href="https://che.openshift.io">che.openshift.io</a>,
      by <strong>Mon Aug 19</strong> to ensure uninterrupted use.
    </p>
    <p>
      Inaction will result in the deletion of your account and data.
    </p>
    <p>
      Deleted accounts cannot be reactivated. To create a new account, please visit <a href="https://che.openshift.io">che.openshift.io</a>.
    </p>
    <p>
      Thanks,<br />
      The Red Hat CodeReady Toolchain team
    </p>
  </div>
  </body>
</html>

---

And the subject of the email is changed to:
"Notice: Your Red Hat CodeReady Toolchain free account is inactive"